### PR TITLE
Rework File Mark page in the documentation

### DIFF
--- a/content/ytt/docs/v0.30.0/file-marks.md
+++ b/content/ytt/docs/v0.30.0/file-marks.md
@@ -1,28 +1,26 @@
 ---
-title: Overview
+title: File Marks
 ---
 
-## File marks
+## Overview
 
 ytt allows to control certain metadata about files via `--file-mark` flag.
 
-- `--file-mark` (optional) Format: `<path>:<mark>=<value>`. Can be specified multiple times. Example: `--file-mark generated.go.txt:exclusive-for-output=true`.
+```
+$ ytt ... --file-mark <path>:<mark>=<value>
+```
 
-Available marks:
+where:
+- `path` — location to the file(s) being marked
+    - exact path (use `--files-inspect` to see paths as seen by ytt)
+    - path with `*` to match files in a directory
+    - path with `**/*` to match files and directories recursively
+- `mark` — metadata to modify on the file(s) selected by `path`
+- `value` — the value for the mark
 
-- `path`: Changes relative path. Example: `generated.go.txt:path=gen.go.txt`.
-- `exclude`: Exclude file from any kind of processing. Values: `true`. Example `config.yml:exclude=true`.
-- `type`: Change type of file. By default type is determined based on file extension. Values: `yaml-template`, `yaml-plain`, `text-template`, `text-plain`, `starlark`, `data`. Example `config.yml:type=data`.
-- `for-output`: Mark file to be used as part of output. Values: `true`. Example `config.lib.yml:for-output=true`.
-- `exclusive-for-output`: Mark file to be used _exclusively_ as part of output. If there is at least one file marked this way, only these files will be used in output. Values: `true`. Example `config.lib.yml:exclusive-for-output=true`.
+Note that this flag can be specified multiple times. 
 
-Path can be following:
-
-- exact path (use `--files-inspect` to see paths as seen by ytt)
-- path with `*` to match files in a directory
-- path with `**/*` to match files and directories recursively
-
-### Example
+Example: 
 
 ```bash
 ytt -f . \
@@ -31,3 +29,99 @@ ytt -f . \
   --file-mark 'generated.go.txt:exclusive-for-output=true' \
   --output-directory ../../tmp/
 ```
+
+## Available Marks
+
+### path
+
+Changes the relative path.
+
+```
+--file-mark '<path>:path=<new-path>'
+```
+
+Example: 
+
+```
+--file-mark 'generated.go.txt:path=gen.go.txt'
+```
+
+renames `generated.go.txt` to `gen.go.txt`
+
+__
+
+### exclude
+
+Exclude file from any kind of processing. 
+
+```
+--file-mark '<path>:exclude=true'
+```
+
+__
+
+### type
+
+Change type of file, affecting how `ytt` processes it. 
+
+```
+--file-mark '<path>:type=<file-type>'
+```
+
+By default `file-type` is determined based on file extension. 
+
+`file-type` can be: 
+- `yaml-template` (ext: `.yml`) — parsed as a YAML document containing `ytt` templating.
+- `yaml-plain` — parsed as a simple YAML document (not processed for templating).
+- `text-template` (ext: `.txt`) — parsed as a text document containing text templating.
+- `text-plain` — plain text (included in output, as is)
+- `starlark` (ext: `.star`) — a Starlark source file (executed)
+- `data` — a text file that can be loaded by [`data.read()`](lang-ref-ytt.md#data)
+ 
+Example:
+
+```
+--file-mark 'config.yml:type=data'
+```
+
+indicates that `config.yml` is _not_ a `yaml-template`, but is `data`. This file will _not_
+be included in the output, but can be loaded using [`data.read()`](lang-ref-ytt.md#data).
+
+__
+
+### for-output
+
+Marks a file that is not part of output by default, to be included.
+
+```
+--file-mark '<path>:for-output=true'
+```
+
+Example
+```
+--file-mark 'config.lib.yml:for-output=true'
+```
+
+By default, `.lib.yml` files are not included in the rendered output (they are loaded
+by other templates).  With this file mark, `config.lib.yml` _is_ included in the output.
+
+__
+
+### exclusive-for-output
+
+Limits output to only marked files.
+
+If there is at least one file marked this way, only these files will be used in output. 
+
+```
+--file-mark '<path>:exclusive-for-output=true'
+```
+
+Example:
+```
+--file-mark 'config.lib.yml:exclusive-for-output=true'
+```
+
+Causes output to only include `config.lib.yml`.
+
+


### PR DESCRIPTION
As part of our website review, @ewrenn8 and I made a significant improvement to this one page in the docs: turning it into a more usable reference.

Once the core work on the redesign is complete, please merge these changes in as well.