### PR TITLE
Add header links and fix list font size

### DIFF
--- a/themes/carvel/assets/scss/_components.scss
+++ b/themes/carvel/assets/scss/_components.scss
@@ -520,6 +520,7 @@
     .docs-content {
         width: 72%;
         float: right;
+        font-size: 14px;
         h3 {
             font-size: 22px;
         }

--- a/themes/carvel/layouts/_default/_markup/render-heading.html
+++ b/themes/carvel/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,1 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a href="#{{ .Anchor | safeURL }}">¶</a></h{{ .Level }}>


### PR DESCRIPTION
This will add link icons to each header in the docs, and make the font sizes the same across the docs.

Signed-off-by: jonasrosland <jrosland@vmware.com>