### PR TITLE
change baseURL to /

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
-baseURL: "https://carvel.dev/"
+---
+baseURL: "/"  # this should be updated to https://carvel.dev once it's deployed
 disablePathToLower: true
 languageCode: en-us
 DefaultContentLanguage: "en"


### PR DESCRIPTION
Since the website is not yet deployed at carvel.dev, some netlify
previews fail to load because it's looking at the full domain location
rather than the local resource. It's odd. Hoping that this will allow
previews to work until we deploy the updated site.