### PR TITLE
Change input flag to read image from tar

### DIFF
--- a/content/imgpkg/docs/latest/air-gapped-workflow.md
+++ b/content/imgpkg/docs/latest/air-gapped-workflow.md
@@ -95,7 +95,7 @@ You have two options how to transfer bundle from one registry to another:
 1. Import the bundle from your tarball to the destination registry:
 
     ```bash-plain
-    $ imgpkg copy --from-tar /tmp/my-image.tar --to-repo registry.corp.com/apps/simple-app-bundle
+    $ imgpkg copy --tar /tmp/my-image.tar --to-repo registry.corp.com/apps/simple-app-bundle
 
     copy | importing 2 images...
     copy | importing index.docker.io/user1/simple-app-bundle@sha256:70225df0a05137ac385c95eb69f89ded3e7ef3a0c34db43d7274fd9eba3705bb -> registry.corp.com/apps/simple-app-bundle@sha256:70225df0a05137ac385c95eb69f89ded3e7ef3a0c34db43d7274fd9eba3705bb...
@@ -107,7 +107,7 @@ You have two options how to transfer bundle from one registry to another:
     The bundle, and all images referenced in the bundle, are copied to the destination registry.
 
     Flags used in the command:
-      * `--from-tar` indicates the path to a tar file containing the assets to be copied to a registry
+      * `--tar` indicates the path to a tar file containing the assets to be copied to a registry
       * `--to-repo` indicates destination bundle location in the registry
 
 ---

--- a/content/imgpkg/docs/latest/commands.md
+++ b/content/imgpkg/docs/latest/commands.md
@@ -68,7 +68,7 @@ Alternatively `copy` can copy a bundle between registries which are not both acc
 ```bash-plain
 $ imgpkg copy -b index.docker.io/k8slt/sample-bundle --to-tar=/Volumes/secure-thumb/bundle.tar
 # ... take thumb driver to a different location ...
-$ imgpkg copy --from-tar=/Volumes/secure-thumb/bundle.tar --to-repo registry.corp.com/user2/sample-bundle-name
+$ imgpkg copy --tar=/Volumes/secure-thumb/bundle.tar --to-repo registry.corp.com/user2/sample-bundle-name
 ```
 
 In either case, the bundle image and all dependent images are copied to the destination location `registry.corp.com/user2/sample-bundle-name`.


### PR DESCRIPTION
Update the documentation of the copy command from tar to use the flag --tar instead of --from-tar to have a more uniform UX

Related vmware-tanzu/carvel-imgpkg#50