### PR TITLE
Update ImagesLock documentation on kbld

### DIFF
--- a/content/kbld/docs/latest/resolving.md
+++ b/content/kbld/docs/latest/resolving.md
@@ -100,11 +100,10 @@ will produce `/tmp/imgpkg.lock.yml`:
 ```yaml
 apiVersion: imgpkg.carvel.dev/v1alpha1
 kind: ImagesLock
-spec:
-  images:
-  - image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
-    annoations:
-      kbld.carvel.dev/id: nginx:1.14.2
+images:
+- image: index.docker.io/library/nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d
+  annotations:
+    kbld.carvel.dev/id: nginx:1.14.2
 ```
 
 An ImagesLock can be included with configuration via `-f` to produce same resolved configuration, for example, `kbld -f input.yml -f /tmp/imgpkg.lock.yml` produces:


### PR DESCRIPTION
The newer version of `imgpkg` updates the ImagesLock file format.

Related to vmware-tanzu/carvel-kbld#87