### PR TITLE
Moved information from /carvel repo to carvel.dev repo for consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ More details: [Directory Structure Explained](https://gohugo.io/getting-started/
 Carvel is better because of our contributors and maintainers. It is because of you that we can bring great software to the community.
 Please join us during our online community meetings. Details can be found on our [Carvel website](https://carvel.dev/community/).
 
-You can chat with us on Kubernetes Slack in the #carvel channel and follow us on Twitter at @carvel_dev.
+You can chat with us on Kubernetes Slack in the [#carvel channel](https://kubernetes.slack.com/archives/CH8KCCKA5) and follow us on Twitter at [@carvel_dev](https://twitter.com/carvel_dev).
 
 Check out which organizations are using and contributing to Carvel: [Adopter's list](https://github.com/vmware-tanzu/carvel/ADOPTERS.md)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,40 @@
 
 # Website for [carvel.dev](https://carvel.dev/)
 
-### Join the Community and Make Carvel Better
-Carvel is better because of our contributors and maintainers. It is because of you that we can bring great software to the community.
-Please join us during our online community meetings. Details can be found on our [Carvel website](https://carvel.dev/community/).
+Carvel provides a set of reliable, single-purpose, composable tools that aid in your application building, configuration, and deployment to Kubernetes.
 
-You can chat with us on Kubernetes Slack in the #carvel channel and follow us on Twitter at @carvel_dev.
+This is a list of repos associated with [Carvel](https://carvel.dev) project.
 
-Check out which organizations are using and contributing to Carvel: [Adopter's list](https://github.com/vmware-tanzu/carvel/ADOPTERS.md)
+* [ytt](https://github.com/vmware-tanzu/carvel-ytt) - Template and overlay Kubernetes configuration via YAML structures, not text documents
+* [kapp](https://github.com/vmware-tanzu/carvel-kapp) - Install, upgrade, and delete multiple Kubernetes resources as one "application"
+* [kbld](https://github.com/vmware-tanzu/carvel-kbld) - Build or reference container images in Kubernetes configuration in an immutable way
+* [imgpkg](https://github.com/vmware-tanzu/carvel-imgpkg) - Bundle and relocate application configuration (with images) via Docker registries
+* [kapp-controller](https://github.com/vmware-tanzu/carvel-kapp-controller) - Capture application deployment workflow in App CRD. Reliable GitOps experience powered by kapp.
+* [vendir](https://github.com/vmware-tanzu/carvel-vendir) - Declaratively state what files should be in a directory.
+
+Experimental:
+
+* [kwt](https://github.com/vmware-tanzu/carvel-kwt)
+* [terraform-provider-carvel](https://github.com/vmware-tanzu/terraform-provider-carvel)
+* [carvel-secretgen-controller](https://github.com/vmware-tanzu/carvel-secretgen-controller)
+
+Installation:
+
+* [homebrew-carvel](https://github.com/vmware-tanzu/homebrew-carvel)
+* [carvel-docker-image](https://github.com/vmware-tanzu/carvel-docker-image)
+* [asdf-carvel](https://github.com/vmware-tanzu/asdf-carvel)
+* [carvel-setup-action](https://github.com/vmware-tanzu/carvel-setup-action)
+
+Plugins:
+
+* [ytt.vim](https://github.com/vmware-tanzu/ytt.vim)
+
+Examples:
+
+* [carvel-simple-app-on-kubernetes](https://github.com/vmware-tanzu/carvel-simple-app-on-kubernetes)
+* [carvel-ytt-library-for-kubernetes](https://github.com/vmware-tanzu/carvel-ytt-library-for-kubernetes)
+* [carvel-ytt-library-for-kubernetes-demo](https://github.com/vmware-tanzu/carvel-ytt-library-for-kubernetes-demo)
+* [carvel-guestbook-example-on-kubernetes](https://github.com/vmware-tanzu/carvel-guestbook-example-on-kubernetes)
 
 ---
 ## Local Development
@@ -39,3 +66,11 @@ Serve site at [http://localhost:1313]()
 - `data/` includes configuration for docs TOCs 
 
 More details: [Directory Structure Explained](https://gohugo.io/getting-started/directory-structure/)
+
+### Join the Community and Make Carvel Better
+Carvel is better because of our contributors and maintainers. It is because of you that we can bring great software to the community.
+Please join us during our online community meetings. Details can be found on our [Carvel website](https://carvel.dev/community/).
+
+You can chat with us on Kubernetes Slack in the #carvel channel and follow us on Twitter at @carvel_dev.
+
+Check out which organizations are using and contributing to Carvel: [Adopter's list](https://github.com/vmware-tanzu/carvel/ADOPTERS.md)


### PR DESCRIPTION
Based on conversations with Aaron, Helen, Jonas, and Vibhas, we moved the information from vmware-tanzu/carvel to vmware-tanzu/carvel.dev for consolidation of information.