### PR TITLE
Fix docs for "load" under alias

### DIFF
--- a/content/ytt/docs/latest/lang-ref-load.md
+++ b/content/ytt/docs/latest/lang-ref-load.md
@@ -15,7 +15,7 @@ Load statement allows to load functions from other modules (such as ones from [b
 - [load](https://github.com/google/starlark-go/blob/master/doc/spec.md#load-statements)
 ```python
 load("@ytt:overlay", "overlay")                # load overlay module from builtin ytt library
-load("@ytt:overlay", "overlay"=ov)             # load overlay symbol under a different alias
+load("@ytt:overlay", ov="overlay")             # load overlay symbol under a different alias
 load("helpers.star", "func1", "func2")         # load func1, func2 from Starlark file
 load("helpers.lib.yml", "func1", "func2")      # load func1, func2 from YAML file
 load("helpers.lib.txt", "func1", "func2")      # load func1, func2 from text file


### PR DESCRIPTION
Hello! This my first PR for YTT, a tiny documentation fix: the syntax for loading under an alias is `alias="origin"`, not `"origin"=alias`.

Using `"overlay"=ov` [as documented here](https://carvel.dev/ytt/docs/latest/lang-ref-load/#usage) produces a syntax error:
```
- got '=', want ','
    config.yml:4 | #@ load("@ytt:overlay", "overlay"=ov)
```

whereas using `ov="overlay"` (or any `alias="original"`) does the right thing.

------------
Here's an example with `@ytt:data`.

Contents of `config.yml`:
```yaml
#@ load("@ytt:data", new_name="data")
list_with_a_map: #@ new_name.values.my_map
```

Contents of `values.yml`:
```yaml
#@data/values
---
my_map:
  key1: value1
  key2: value2
```

Output of `ytt -f config.yml -f values.yml`:
```yaml
list_with_a_map:
  key1: value1
  key2: value2
```