### PR TITLE
Packaging Docs Feedback

### DIFF
--- a/content/kapp-controller/docs/latest/install-alpha.md
+++ b/content/kapp-controller/docs/latest/install-alpha.md
@@ -1,0 +1,16 @@
+## Install alpha release of kapp-controller
+
+The alpha release of kapp-controller contains the packaging APIs, which are undergoing active development. The alpha release should only 
+be used for experimenting with the packaging APIs as there will be possible breaking changes as further feedback is collected.
+
+To install with `kapp`:
+
+```bash
+$ kapp deploy -a kc -f https://raw.githubusercontent.com/vmware-tanzu/carvel-kapp-controller/dev-packaging/alpha-releases/v0.17.0-alpha.1.yml
+```
+
+To install with `kubectl`:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/carvel-kapp-controller/dev-packaging/alpha-releases/v0.17.0-alpha.1.yml
+```

--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -2,7 +2,7 @@
 title: Package Authoring
 ---
 
-Available in v0.17.0-alpha.1+
+Available in [v0.17.0-alpha.1+](https://github.com/vmware-tanzu/carvel-kapp-controller/tree/dev-packaging/alpha-releases)
 
 Before jumping in, we recommend reading through the docs about the new [packaging
 APIs](packaging.md) to familiarize yourself with the YAML configuration used in these

--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -102,7 +102,8 @@ $ kbld -f package-contents/config/ --imgpkg-lock-output package-contents/.imgpkg
 For more on using kbld to populate the `.imgpkg` directory with an ImageLock, and why it is useful,
 see the [imgpkg docs on the subject](/imgpkg/docs/latest/resources/#imageslock-configuration)
 
-Once these files have been added, our package contents bundle is ready to be pushed:
+Once these files have been added, our package contents bundle is ready to be pushed as shown below 
+(**NOTE:** replace `registry.corp.com/packages/` if working through example):
 
 ```bash
 $ imgpkg push -b registry.corp.com/packages/simple-app:1.0.0 -f package-contents/
@@ -142,6 +143,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
+          # replace image registry and repo with one you are using
           image: registry.corp.com/packages/simple-app:1.0.0
       template:
       - ytt:
@@ -155,7 +157,9 @@ spec:
       - kapp: {}
 ```
 
-Lets store this in a file named `simple-app.corp.com.1.0.0.yml`.
+Lets store this in a file named `simple-app.corp.com.1.0.0.yml`. Remember to replace 
+`registry.corp.com/packages/` in the YAML above with your registry and repository if 
+following along. 
 
 ---
 ### Testing your package
@@ -203,4 +207,5 @@ With the metadata files present, we can push our repo image to whatever OCI regi
 $ imgpkg push -i registry.corp.com/packages/my-pkg-repo:1.0.0 -f my-pkg-repo
 ```
 
-Package repository is pushed! Follow [Adding package repository](package-consumption.md#installing-a-package) step from Package consumption workflow to see how to let kapp-controller know about this repository.
+The package repository is pushed. Follow the [Adding package repository](package-consumption.md#adding-package-repository) step from the 
+package consumption workflow to see an example of adding and using a PackageRepository with kapp-controller.

--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -4,16 +4,20 @@ title: Package Authoring
 
 Before jumping in, we recommend reading through the docs about the new [packaging
 APIs](packaging.md) to familiarize yourself with the YAML configuration used in these
-workflows.
-
-These workflows also assume some of the other Carvel tools are installed on your
-system, namely `kapp`, `imgpkg`, and `kbld`. For more info on how to install
-these, see our [install section on the homepage](/#whole-suite)
+workflows. 
 
 This workflow walks through an example that will help a user transform a stack
 of plain Kubernetes manifests in to a Package within a PackageRepository. This will
 allow them to distribute their apps in a way that is easily installable by any
 consumers running a kapp-controller in their cluster.
+
+## Prerequisites
+
+To go through the examles below, the following prerequisites are assumed:
+* You will need to [install the alpha release](install-alpha.md) of kapp-controller on a Kubernetes cluster.
+* These workflows also assume some of the other Carvel tools are installed on your
+system, namely `kapp`, `imgpkg`, and `kbld`. For more info on how to install
+these, see our [install section on the homepage](/#whole-suite).
 
 ## Creating a package
 

--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -2,6 +2,8 @@
 title: Package Authoring
 ---
 
+Available in v0.17.0-alpha.1+
+
 Before jumping in, we recommend reading through the docs about the new [packaging
 APIs](packaging.md) to familiarize yourself with the YAML configuration used in these
 workflows. 

--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -14,7 +14,7 @@ the [`packaging-demo`](https://github.com/vmware-tanzu/carvel-kapp-controller/tr
 ## Prerequisites
 
 * You will need to [install the alpha release](install-alpha.md) on a Kubernetes cluster to go through the examples.
-* The instructions below assume [`kapp`](/#whole-suite) and `kubectl` are installed.
+* The instructions below assume [`kapp`](/kapp) and `kubectl` are installed.
 
 ## Adding package repository
 
@@ -25,15 +25,15 @@ kapp-controller needs to know which packages are available to install. One way t
 apiVersion: install.package.carvel.dev/v1alpha1
 kind: PackageRepository
 metadata:
-  name: basic.test.carvel.dev
+  name: simple-package-repository
 spec:
   fetch:
     image:
-      url: k8slt/kctrl-pkg-repo:v1.0.0
+      url: k8slt/corp-com-pkg-repo:1.0.0
 ```
 
 This CR will allow kapp-controller to install any of the packages found within
-the imgpkg bundle `k8slt/kctrl-pkg-repo:v1.0.0`, which is stored in a OCI registry. Save this PackageRepository to
+the image `k8slt/kctrl-pkg-repo:v1.0.0`, which is stored in a OCI registry. Save this PackageRepository to
 a file named repo.yml and then apply it to the cluster using kapp:
 
 ```bash
@@ -44,10 +44,10 @@ Once the deploy has finished, we are able to list the packages and see which one
 
 ```bash
 $ kubectl get packages
-NAME                              PUBLIC-NAME            VERSION      AGE
-pkg.test.carvel.dev.1.0.0         pkg.test.carvel.dev   1.0.0        7s
-pkg.test.carvel.dev.2.0.0         pkg.test.carvel.dev   2.0.0        7s
-pkg.test.carvel.dev.3.0.0-rc.1    pkg.test.carvel.dev   3.0.0-rc.1   7s
+NAME                             PUBLIC-NAME           VERSION      AGE
+simple-app.corp.com.1.0.0        simple-app.corp.com   1.0.0        20s
+simple-app.corp.com.2.0.0        simple-app.corp.com   2.0.0        20s
+simple-app.corp.com.3.0.0-rc.1   simple-app.corp.com   3.0.0-rc.1   20s
 ```
 
 If we want, we can inspect these packages further to get more info about what they're installing:
@@ -63,12 +63,12 @@ This will show us the package yaml, which will look something like this:
 apiVersion: package.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: pkg.test.carvel.dev.1.0.0
+  name: simple-app.corp.com.1.0.0
 spec:
-  publicName: pkg.test.carvel.dev
+  publicName: simple-app.corp.com
   version: 1.0.0
-  displayName: "Test Package in repo"
-  description: "Package used for testing"
+  displayName: "simple-app v1.0.0"
+  description: "Package for simple-app version 1.0.0"
   template:
     spec:
       fetch:
@@ -106,7 +106,7 @@ metadata:
 spec:
   serviceAccountName: default-ns-sa
   packageRef:
-    publicName: pkg.test.carvel.dev
+    publicName: simple-app.corp.com
     version: 1.0.0
   values:
   - secretRef:
@@ -169,8 +169,8 @@ And we see that our hello_msg value is used.
 
 ## Uninstalling a package
 
-To uninstall a package simply delete InstalledPackage CR
+To uninstall a package, simply delete the InstalledPackage CR:
 
 ```bash
-$ kubectl delete installedpackage pkg-demo
+$ kapp delete -a pkg-demo
 ```

--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -2,6 +2,8 @@
 title: Package Consumption
 ---
 
+Available in v0.17.0-alpha.1+
+
 Before jumping in, we recommend reading through the docs about the new [packaging
 apis](packaging.md) to familiarize yourself with the YAML configuration used in these
 workflows.

--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -9,6 +9,11 @@ workflows.
 This workflow walks through the example contained in
 the [`packaging-demo`](https://github.com/vmware-tanzu/carvel-kapp-controller/tree/dev-packaging/examples/packaging-demo).
 
+## Prerequisites
+
+* You will need to [install the alpha release](install-alpha.md) on a Kubernetes cluster to go through the examples.
+* The instructions below assume [`kapp`](/#whole-suite) and `kubectl` are installed.
+
 ## Adding package repository
 
 kapp-controller needs to know which packages are available to install. One way to let it know about available packages is by registering a package repository. To do this, we need a PackageRepository CR:

--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -2,7 +2,7 @@
 title: Package Consumption
 ---
 
-Available in v0.17.0-alpha.1+
+Available in [v0.17.0-alpha.1+](https://github.com/vmware-tanzu/carvel-kapp-controller/tree/dev-packaging/alpha-releases)
 
 Before jumping in, we recommend reading through the docs about the new [packaging
 apis](packaging.md) to familiarize yourself with the YAML configuration used in these

--- a/content/kapp-controller/docs/latest/packaging.md
+++ b/content/kapp-controller/docs/latest/packaging.md
@@ -2,7 +2,7 @@
 title: Packaging
 ---
 
-Available in v0.17.0-alpha.1+
+Available in [v0.17.0-alpha.1+](https://github.com/vmware-tanzu/carvel-kapp-controller/tree/dev-packaging/alpha-releases)
 
 **Disclaimer:** These APIs are still very much in an alpha stage, so changes
 will almost certainly be made and no backwards compatibility is guaranteed

--- a/content/kapp-controller/docs/latest/packaging.md
+++ b/content/kapp-controller/docs/latest/packaging.md
@@ -15,13 +15,9 @@ InstalledPackage, which are described further in their respective sections.
 As this is still an alpha feature, we would love any and all feedback regarding these
 APIs or any documentation relating to them! (Ping us on Slack)
 
-## Install alpha release of kapp-controller
+## Install
 
-Run:
-
-```bash
-$ kapp deploy -a kc -f https://raw.githubusercontent.com/vmware-tanzu/carvel-kapp-controller/dev-packaging/alpha-releases/v0.17.0-alpha.1.yml
-```
+See the documentation on [installing the alpha release of kapp-controller](install-alpha.md).
 
 ## Terminology
 

--- a/data/kapp-controller/docs/kapp-controller-latest-toc.yml
+++ b/data/kapp-controller/docs/kapp-controller-latest-toc.yml
@@ -29,6 +29,8 @@ toc:
     subfolderitems:
       - page: Terminology & APIs
         url: /packaging
+      - page: Install
+        url: /install-alpha
       - page: Authoring packages
         url: /package-authoring
       - page: Consuming packages


### PR DESCRIPTION
This pull request addresses the following points of feedback for kapp-controller packaging docs:
* Rename examples in packaging consumption walkthrough to match authoring walkthrough (`pkg.test.carvel.dev` -> `simple-app.corp.com`)
* Separate alpha release installation into its own page (will be deleted later on in favor of regular installation docs)
* Add `Available in v0.17.0-alpha.1+` to all packaging docs
* Minor touch ups to language/spacing issues in walkthroughs