### PR TITLE
Fix kapp-controller docs using - as path

### DIFF
--- a/content/kapp-controller/docs/latest/app-spec.md
+++ b/content/kapp-controller/docs/latest/app-spec.md
@@ -152,14 +152,17 @@ spec:
                 directoryPath: dir
         # lists paths to provide to ytt explicitly (optional)
         paths:
+        # - must be quoted when included with paths
+        - "-"
         - dir/common
         - dir/nested/app
 
     # use kbld to resolve image references to use digests
     - kbld:
         # lists paths to use explicitly (optional; v0.13.0+)
+        # - must be quoted when included with paths
         paths:
-        - -
+        - "-"
         - .imgpkg/images.yml
 
     # use helm template command to render helm chart

--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -151,7 +151,7 @@ spec:
           - config/
       - kbld:
           paths:
-          - -
+          - "-"
           - .imgpkg/images.yml
       deploy:
       - kapp: {}

--- a/content/kapp-controller/docs/latest/packaging.md
+++ b/content/kapp-controller/docs/latest/packaging.md
@@ -77,7 +77,8 @@ spec:
           - config/
       - kbld:
           paths:
-          - -
+          # - must be quoted when included with paths
+          - "-"
           - .imgpkg/images.yml
       deploy:
       - kapp: {}


### PR DESCRIPTION
Related issue: https://github.com/vmware-tanzu/carvel-kapp-controller/issues/115

`-` must be quoted because otherwise yaml thinks it is the beginning of new array.