### PR TITLE
Add fileMarks property to App Spec Docs

### DIFF
--- a/content/kapp-controller/docs/latest/app-spec.md
+++ b/content/kapp-controller/docs/latest/app-spec.md
@@ -156,6 +156,13 @@ spec:
         - "-"
         - dir/common
         - dir/nested/app
+        # control metadata about input files passed to ytt (optional; v0.18.0+)
+        # see https://carvel.dev/ytt/docs/latest/file-marks/ for more details
+        fileMarks:
+        - file-content:type=yaml-plain
+        - dir/common/bom**/*:type=text-plain
+        - dir/nested/app/file.txt:exclude=true
+        - dir/common/generated.go.txt:path=gen.go.txt
 
     # use kbld to resolve image references to use digests
     - kbld:


### PR DESCRIPTION
Adding the `fileMarks` property to the App spec documentation. Related kapp-controller pr is https://github.com/vmware-tanzu/carvel-kapp-controller/pull/144.

This property will not be available until v0.18.0 of kapp-controller is cut.