### PR TITLE
Add noopDelete to App Spec Docs

### DIFF
--- a/content/kapp-controller/docs/latest/app-spec.md
+++ b/content/kapp-controller/docs/latest/app-spec.md
@@ -19,6 +19,11 @@ spec:
   # cancels current and future reconciliations (optional; default=false)
   canceled: true
 
+  # Deletion requests for the App will result in the App CR being
+  # deleted, but its associated resources will not be deleted 
+  # (optional; default=false; v0.18.0+)
+  noopDelete: true
+
   # specifies that app should be deployed authenticated via
   # given service account, found in this namespace (optional; v0.6.0+)
   serviceAccountName: sa-name


### PR DESCRIPTION
Associated docs for adding `noopDelete` to the App spec. See the following pr for more details on the feature added to kapp-controller: https://github.com/vmware-tanzu/carvel-kapp-controller/pull/146