### PR TITLE
Document Bare Minimum Permissions for Creating App/InstalledPackage CR via ServiceAccount

### DIFF
--- a/content/kapp-controller/docs/latest/security-model.md
+++ b/content/kapp-controller/docs/latest/security-model.md
@@ -20,3 +20,22 @@ Example:
 - User A has been granted access to namespace `a` (and no other namespace or cluster level access). User A can create an App CR with a service account located in namespace `a` to deploy resources into namespace `a`. It _is not_ possible for user A to create an App CR that would install cluster-wide resources or place resources into another namespace. (e.g. a user that just deploys web application to their namespace)
 
 - User B has been granted access to namespace `b` and ability to manage specifically named CRD (single scoped cluster-wide privilege). User B can create an App CR with a service account located in namespace `b` that installs app into namespace `b` and also manages single CRD lifecycle. (e.g. a user that manages another controller for other users)
+
+## Minimum ServiceAccount Permissions
+
+For users managing App and InstalledPackage CR privileges via a service account, the verbs in the role below are needed for working with ConfigMaps. 
+
+```yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: app-ip-cr-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "create", "update", "delete"]
+```
+
+These permissions are needed because of how `kapp` tracks information about apps it manages, which is via storing information in a ConfigMap. So even if your App or InstalledPackage CR does not create ConfigMaps, the service account will still need permissions for working with ConfigMaps.
+
+The ConfigMap permissions above are needed in addition to any other resource/verb combinations needed to deploy all resources created by the App and InstalledPackage CRs.


### PR DESCRIPTION
Adding some documentation to help make it clear what minimum rbac permissions are for creating Apps via kapp-controller.