### PR TITLE
Update docs for missing_ok to fix error

### DIFF
--- a/content/ytt/docs/latest/lang-ref-ytt-overlay.md
+++ b/content/ytt/docs/latest/lang-ref-ytt-overlay.md
@@ -200,7 +200,7 @@ Specifies which nodes on the "left" to modify.
       - `found` (`Int`) — number of actual matches
    - `List[Int|String|Function]` — must match one of the given criteria
    - Default: `1` (`Int`) (i.e. expecting to match exactly one (1) node on the "left").
-- **`missing_ok=`**`Bool` (optional) shorthand syntax for `expects="0+"`
+- **`missing_ok=`**`Bool` (optional) shorthand syntax for `expects=[0,1]`
 - **`when=`**`Int|String|List` (optional) criteria for when the overlay should apply. If the criteria is met, the overlay applies; otherwise, nothing happens.
    - `Int` — must equal this number, exactly
    - `String` (e.g. `"1+"`) — must match _at least_ the number


### PR DESCRIPTION
The docs previously had some conficting information, on one line saying:

> missing_ok=Bool (optional) shorthand syntax for expects="0+"

And on another:

> #@overlay/match missing_ok=True: expects to find 0 or 1 matching nodes on the “left”

After testing it, I determined that the actual behaviour is equivalent to `expects=[0,1]`