### PR TITLE
Remove Docs that Reference PackageRepo App and Add in Namespacing for Packaging Resources

### DIFF
--- a/content/kapp-controller/docs/latest/air-gapped-workflow.md
+++ b/content/kapp-controller/docs/latest/air-gapped-workflow.md
@@ -61,7 +61,7 @@ spec:
 ```
 
 In the event your PackageRepository needs authentication to pull the bundle, you can specify credentials via a `secretRef` 
-as shown below. The secret for the `secretRef` property must be created in the `kapp-controller` namespace for the PackageRepository 
+as shown below. The secret for the `secretRef` property must be created in the namespace where the PackageRepository was created
 to use this secret. Supported secret keys are documented [here](config#imgpkgbundle-authentication). This authentication pattern will 
 change in the future as better workflows are proposed for kapp-controller.
 

--- a/content/kapp-controller/docs/latest/debugging.md
+++ b/content/kapp-controller/docs/latest/debugging.md
@@ -104,10 +104,8 @@ pulled from an OCI registry as an [imgpkgBundle](/imgpkg/docs/latest/resources/#
 often happen from fetching the PackageRepository contents (i.e. the `.spec.fetch` portion of the PackageRepository spec).
 
 Failures for PackageRepositories can be viewed directly via the `usefulErrorMessage` property of the PackageRepository's status. 
-This `usefulErrorMessage` property comes from an App CR that is created as a result of creating a PackageRepository. This App is 
-currently always created in the `kapp-controller` namespace, but this may change in the futrue. More information on interpreting 
-the error message from `usefulErrorMessage` can be found under the [Debugging App CRs](#debugging-app-crs). The underlying App CR 
-will have the same name as the PackageRepository that you create.
+Interpreting the error message from `usefulErrorMessage` for PackageRepositories is very similar to debugging an App CR's status. 
+More information on interpreting the errors from App CRs can be found under under the [Debugging App CRs](#debugging-app-crs) section. 
 
 Common problems encountered with PackageRepositories may be needing authentication for a registry where an image or imgpkg bundle is 
 stored (read more [here](package-consumption/#adding-package-repository) on PackageRepositories authenticating to a private registry) 

--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -48,17 +48,14 @@ spec:
       secretRef:
         name: my-registry-creds
 ```
-This secret will need to be located in the kapp-controller namespace and be of
-the format described in the [fetch docs](config.md#image-authentication).
 
-**Note:** This is a temporary authentication model and will change in the
-future.
+This secret will need to be located in the namespace where the PackageRepository 
+is created and be in the format described in the [fetch docs](config.md#image-authentication).
 
 This PackageRepository CR will allow kapp-controller to install any of the
 packages found within the `k8slt/kctrl-pkg-repo:v1.0.0` imgpkg bundle, which is
 stored in an OCI registry. Save this PackageRepository to a file named repo.yml
 and then apply it to the cluster using kapp:
-
 
 
 ```bash

--- a/content/kapp-controller/docs/latest/packaging.md
+++ b/content/kapp-controller/docs/latest/packaging.md
@@ -150,6 +150,12 @@ metadata:
   name: basic.vmware.com
   # PackageRepository is a cluster scoped resource, so no namespace
 spec:
+  # pauses _future_ reconcilation; does _not_ affect
+  # currently running reconciliation (optional; default=false)
+  paused: true
+  # specifies the length of time to wait, in time + unit
+  # format, before reconciling.(optional; default=5m)
+  syncPeriod: 1m
   # Must have only one directive.
   fetch:
     # pulls imgpkg bundle from Docker/OCI registry

--- a/content/kapp-controller/docs/latest/packaging.md
+++ b/content/kapp-controller/docs/latest/packaging.md
@@ -9,9 +9,9 @@ will almost certainly be made and no backwards compatibility is guaranteed
 between alpha versions.
 
 The new alpha release of kapp-controller adds new APIs to bring common package
-management workflows to a Kubernetes cluster.  This is done using four new CRs:
+management workflows to a Kubernetes cluster. This is done using four new CRs:
 PackageRepository, Package, PackageVersion, and InstalledPackage, which are
-described further in their respective sections.  As this is still an alpha
+described further in their respective sections. As this is still an alpha
 feature, we would love any and all feedback regarding these APIs or any
 documentation relating to them! (Ping us on Slack)
 
@@ -56,7 +56,7 @@ metadata:
   # Must consist of three segments separated by a '.'
   # Cannot have a trailing '.'
   name: fluent-bit.vmware.com
-  # Package is a cluster scoped resource, so no namespace
+  namespace: my-ns
 spec:
   # Human friendly name of the package (optional; string)
   displayName: "Fluent Bit"
@@ -96,6 +96,7 @@ kind: PackageVersion
 metadata:
   # Must begin with '<spec.packageName>.' (Note the period)
   name: fluent-bit.carvel.dev.1.5.3
+  namespace: my-ns
 spec:
   # The name of the package this version belongs to
   # Must be a valid package name (see Package CR for details)
@@ -198,6 +199,7 @@ apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageRepository
 metadata:
   name: my-pkg-repo.corp.com
+  namespace: my-ns
 spec:
   fetch:
     imgpkgBundle:

--- a/content/kapp-controller/docs/latest/packaging.md
+++ b/content/kapp-controller/docs/latest/packaging.md
@@ -148,7 +148,7 @@ kind: PackageRepository
 metadata:
   # Any user-chosen name that describes package repository
   name: basic.vmware.com
-  # PackageRepository is a cluster scoped resource, so no namespace
+  namespace: my-ns
 spec:
   # pauses _future_ reconcilation; does _not_ affect
   # currently running reconciliation (optional; default=false)


### PR DESCRIPTION
These docs changes are part of changes introduced in https://github.com/vmware-tanzu/carvel-kapp-controller/pull/219. These changes have not been introduced to the kapp-controller develop branch and these doc changes shouldn't be merged until those changes are. 

This pull request also introduces namespacing packaging resources and removes references that these resources are cluster scoped.
