### PR TITLE
Documentation on Versioning InstalledPackages

### DIFF
--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -57,7 +57,6 @@ packages found within the `k8slt/kctrl-pkg-repo:v1.0.0` imgpkg bundle, which is
 stored in an OCI registry. Save this PackageRepository to a file named repo.yml
 and then apply it to the cluster using kapp:
 
-
 ```bash
 $ kapp deploy -a repo -f repo.yml
 ```
@@ -215,8 +214,12 @@ stringData:
 ```
 
 This CR references the PackageVersion we decided to install in the previous
-section using the package versions `packageName` and `version` fields. The
-InstalledPackage also references the service account which will be used to
+section using the PackageVersion's `packageName` and `version` fields. 
+The `versionSelection` property has a `constraints` subproperty to specify what 
+PackageVersion kapp-controller should install. More information on InstalledPackage 
+versioning can be found [here](packaging#versioning-installedpackages).
+
+The InstalledPackage also references the service account which will be used to
 install the package, as well as values to include in the templating step in
 order to customize our installation.
 

--- a/content/kapp-controller/docs/latest/packaging.md
+++ b/content/kapp-controller/docs/latest/packaging.md
@@ -240,7 +240,7 @@ spec:
   serviceAccountName: fluent-bit-sa
   packageVersionRef:
     # Specifies the name of the package to install (required)
-    packageName: flluent-bit.vmware.com
+    packageName: fluent-bit.vmware.com
     # Selects version of a package based on constraints provided (optional)
     # Either version or versionSelection is required.
     versionSelection:
@@ -331,3 +331,67 @@ my-pkg-repo/
     - Always have a Package CR if you have PackageVersion CRs
 
 See [Creating a Package Repository](package-authoring.md#creating-a-package-repository) for example creation steps.
+
+---
+## Versioning InstalledPackages
+
+The following sections cover aspects of how to approach versioning when using InstalledPackages. 
+
+### Constraints
+
+InstalledPackages offer a property called `constraints` under `.spec.packageVersionRef.versionSelection`. 
+This `constraints` property can be used to select a specific PackageVersion to install or include a set of 
+conditions to pick a version. This `constraints` property is based on semver ranges and more details on 
+conditions that can be included with `constraints` can be found [here](https://github.com/blang/semver#ranges).
+
+To select a specific version of a PackageVersion to use with an InstalledPackage, the full version (i.e. `.spec.version` 
+from a PackageVersion) can be included in the `constraints` property, such as what is shown below:
+
+```yaml
+packageVersionRef:
+  packageName: fluent-bit.vmware.com
+  versionSelection:
+    constraints: "1.5.3"
+```
+
+The example above will result in version 1.5.3 of the Package being installed.
+
+An example of using a condition to select a PackageVersion with `constraints` is shown below:
+
+```yaml
+packageVersionRef:
+  packageName: fluent-bit.vmware.com
+  versionSelection:
+    constraints: ">1.5.3"
+```
+
+The above constraint will result in any version greater than 1.5.3 of the Package being installed. 
+It will also automatically update to the latest versions of the Package as they become available on 
+the cluster.
+
+### Prereleases
+
+When creating an InstalledPackage, by default prereleases (i.e. release versions that don't follow a semver format) are not included 
+by kapp-controller when considering whether a PackageVersion exists or not. To include prereleases when creating an InstalledPackage, 
+the following can be added to the InstalledPackage spec:
+
+```yaml
+versionSelection:
+  constraints: "3.0.0-rc.1"
+  prereleases: {}
+```
+
+Specifying `prereleases: {}` will make kapp-controller consider all available prereleases when seeing if a PackageVersion is available to be 
+installed. 
+
+To filter by releases containing certain substrings, there is an `identifiers` property under `prereleases` that can be used to only include 
+certain prereleases that contain the identifier, such as what is shown below:
+
+```yaml
+versionSelection:
+  constraints: "3.0.0"
+  prereleases:
+    identifiers: [rc]
+```
+
+Multiple identifiers can be specified in the event that Package's prereleases contain multiple identifiers (e.g. `identifiers: [rc, beta]`).


### PR DESCRIPTION
Part of https://github.com/vmware-tanzu/carvel-kapp-controller/issues/211

This pull request addresses the following part of the issue above:

> We should add docs on how a consumer can install a pre-release version.