### PR TITLE
Add valuesSchema Examples to Docs

### DIFF
--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -161,6 +161,32 @@ spec:
   version: 1.0.0
   releaseNotes: |
     Initial release of the simple app package
+  valuesSchema:
+    openAPIv3:
+      title: simple-app.corp.com values schema
+      examples:
+      - svc_port: 80
+        app_port: 80
+        hello_msg: stranger
+      properties:
+        svc_port:
+          type: integer
+          description: Port number for the service.
+          default: 80
+          examples:
+          - 80
+        app_port:
+          type: integer
+          description: Target port for the application.
+          default: 80
+          examples:
+          - 80
+        hello_msg:
+          type: string
+          description: Name used in hello message from app when app is pinged.
+          default: stranger
+          examples:
+          - stranger
   template:
     spec:
       fetch:
@@ -178,10 +204,14 @@ spec:
       deploy:
       - kapp: {}
 ```
+
 This PackageVersion contains some metadata fields specific to the verison, such
-as releaseNotes, but the main component of it is the template section, which
+as releaseNotes and a valuesSchema that shows what properties of this PackageVersion 
+are configurable, but the main component of it is the template section, which
 informs kapp-controller of the actions required to install the packaged
-software. This section is an App template, so take a look at the
+software. 
+
+This section is an App template, so take a look at the
 [app-spec](app-spec.md) section to learn more about what each of the template
 sections are for. For this example, we have chosen a basic setup that will fetch
 the imgpkg bundle we created in the previous section, run the templates stored

--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -136,6 +136,32 @@ spec:
   version: 2.0.0
   releaseNotes: |
     Adds overlays to control the number of pods
+  valuesSchema:
+    openAPIv3:
+      title: simple-app.corp.com values schema
+      examples:
+      - svc_port: 80
+        app_port: 80
+        hello_msg: stranger
+      properties:
+        svc_port:
+          type: integer
+          description: Port number for the service.
+          default: 80
+          examples:
+          - 80
+        app_port:
+          type: integer
+          description: Target port for the application.
+          default: 80
+          examples:
+          - 80
+        hello_msg:
+          type: string
+          description: Name used in hello message from app when app is pinged.
+          default: stranger
+          examples:
+          - stranger
   template:
     spec:
       deploy:
@@ -187,7 +213,6 @@ metadata:
   name: pkg-demo-values
 stringData:
   values.yml: |
-    #@data/values
     ---
     hello_msg: "hi"
 ```
@@ -197,6 +222,13 @@ section using the package versions `packageName` and `version` fields. The
 InstalledPackage also references the service account which will be used to
 install the package, as well as values to include in the templating step in
 order to customize our installation.
+
+As part of installing this PackageVersion, another thing you will notice is 
+that a Kubernetes secret will be created. This secret contains a values.yml 
+file where configurable properties defined in the PackageVersion valuesSchema 
+can be specified. The InstalledPackage references these configurable values via 
+a values property and a secretRef can be used to reference the secret with the 
+configured values.
 
 To install above package, we will also need to create `default-ns-sa` service account (refer to [Security model](security-model.md) for explanation of how service accounts are used) that give kapp-controller privileges to create resources in the default namespace:
 

--- a/content/kapp-controller/docs/latest/packaging.md
+++ b/content/kapp-controller/docs/latest/packaging.md
@@ -118,6 +118,23 @@ spec:
   - "MIT"
   # Timestamp of release (iso8601 formatted string; optional)
   releasedAt: 2021-05-05T18:57:06Z
+  # valuesSchema can be used to show template values that
+  # can be configured by users when a PackageVersion is installed.
+  # These values should be specified in an OpenAPI schema format. (optional)
+  valuesSchema:
+    # openAPIv3 key can be used to declare template values in OpenAPIv3 
+    # format 
+    openAPIv3:
+      title: fluent-bit.carvel.dev.1.5.3 values schema
+      examples:
+      - namespace: fluent-bit
+      properties:
+        namespace:
+          type: string
+          description: Namespace where fluent-bit will be installed.
+          default: fluent-bit
+          examples:
+          - fluent-bit
   # App template used to create the underlying App CR.
   # See 'App CR Spec' docs for more info
   template:


### PR DESCRIPTION
Part of vmware-tanzu/carvel-kapp-controller#211

This pull request addresses the following part of the issue above:

> We should add docs on how to use OpenAPI schema in PackageVersion CR. We can use an example and add it to the "Terminology & APIs" page and also on the "Authoring packages" page.]