### PR TITLE
Basic workflow updates for kapp-controller docs

### DIFF
--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -89,9 +89,9 @@ reference to the greeter app image
 To start, lets create a directory with the above configuration files:
 
 ```bash
-$ mkdir -p package-contents/config/
-$ mv <path to config.yml> package-contents/config/config.yml
-$ mv <path to values.yml> package-contents/config/values.yml
+$ mkdir -p package-contents/
+$ mv <path to config.yml> package-contents/config.yml
+$ mv <path to values.yml> package-contents/values.yml
 ```
 
 ([Package bundle format](packaging.md#package-bundle-format) describes the purpose of each directory as well as general recommendations.)
@@ -149,7 +149,7 @@ Before moving on, save this yaml snippet to a file named
 
 Lastly, we need to create a Package CR. This CR contains versioned instructions
 and metadata used to install packaged sofwtare that fits the description
-provided in the PackageMetadata CR we just created. An example Package CR
+provided in the PackageMetadata CR we just saved in `metadata.yml`. An example Package CR
 follows.
 
 ```yaml
@@ -238,7 +238,7 @@ available on the cluster, so let's apply the Package and PackageMetadata CRs we
 just created directly to the cluster:
 
 ```
-$ kapp deploy -a package -f 1.0.0.yml -f metadata.yml
+$ kapp deploy -a package -f 1.0.0.yml -f metadata.yml -y
 ```
 
 Typically these CRs are made available to the cluster from a package repository,
@@ -297,7 +297,8 @@ $ kbld -f my-pkg-repo/packages/ --imgpkg-lock-output my-pkg-repo/.imgpkg/images.
 ```
 
 With the bundle metadata files present, we can push our bundle to whatever OCI registry
-we plan to distribute it from:
+we plan to distribute it from (**NOTE:** replace `registry.corp.com/packages/` if working 
+through example):
 
 ```bash
 $ imgpkg push -b registry.corp.com/packages/my-pkg-repo:1.0.0 -f my-pkg-repo

--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -89,9 +89,9 @@ reference to the greeter app image
 To start, lets create a directory with the above configuration files:
 
 ```bash
-$ mkdir -p package-contents/
-$ mv <path to config.yml> package-contents/config.yml
-$ mv <path to values.yml> package-contents/values.yml
+$ mkdir -p package-contents/config/
+$ mv <path to config.yml> package-contents/config/config.yml
+$ mv <path to values.yml> package-contents/config/values.yml
 ```
 
 ([Package bundle format](packaging.md#package-bundle-format) describes the purpose of each directory as well as general recommendations.)

--- a/content/kapp-controller/docs/latest/package-authoring.md
+++ b/content/kapp-controller/docs/latest/package-authoring.md
@@ -23,7 +23,7 @@ these, see our [install section on the homepage](/#whole-suite).
 
 ### Configuration
 
-For this demo, we will be using [ytt](/ytt) templates that describe simple Kubernetes Deployment and Service. These templates will install a simple greeter app with a templated hello message. The templates consist of two files:
+For this demo, we will be using [ytt](/ytt) templates that describe a simple Kubernetes Deployment and Service. These templates will install a simple greeter app with a templated hello message. The templates consist of two files:
 
 `config.yml`:
 
@@ -104,7 +104,7 @@ $ kbld -f package-contents/config/ --imgpkg-lock-output package-contents/.imgpkg
 ```
 
 For more on using kbld to populate the `.imgpkg` directory with an ImagesLock, and why it is useful,
-see the [imgpkg docs on the subject](/imgpkg/docs/latest/resources/#imageslock-configuration)
+see the [imgpkg docs on the subject](/imgpkg/docs/latest/resources/#imageslock-configuration).
 
 Once these files have been added, our package contents bundle is ready to be pushed as shown below
 (**NOTE:** replace `registry.corp.com/packages/` if working through example):

--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -52,7 +52,7 @@ This secret will need to be located in the namespace where the PackageRepository
 is created and be in the format described in the [fetch docs](config.md#image-authentication).
 
 This PackageRepository CR will allow kapp-controller to install any of the
-packages found within the `k8slt/kctrl-pkg-repo:v1.0.0` imgpkg bundle, which is
+packages found within the `k8slt/kctrl-pkg-repo:1.0.0` imgpkg bundle, which is
 stored in an OCI registry. Save this PackageRepository to a file named repo.yml
 and then apply it to the cluster using kapp:
 
@@ -162,22 +162,21 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: k8slt/kctrl-example-pkg:v1.0.0
+          image: index.docker.io/k8slt/kctrl-example-pkg@sha256:8ffa7f9352149dba1d539d0006b38eda357917edcdd39b82497a61dab2c27b75
       template:
       - ytt:
           paths:
-          - "config.yml"
-          - "values.yml"
+          - config/
       - kbld:
           paths:
-          - "-"
-          - ".imgpkg/images.yml"
+          - '-'
+          - .imgpkg/images.yml
       deploy:
       - kapp: {}
 ```
 
 Here we can see this version will fetch the templates stored in the
-`k8slt/kctrl-example-pkg:v1.0.0` bundle, template them using ytt and kbld, and
+`k8slt/kctrl-example-pkg:1.0.0` bundle, template them using ytt and kbld, and
 finally deploy them using kapp. Once deployed, there will be a basic greeter app
 running in the cluster. Since this is what we want, we can now move on to
 installation.

--- a/content/kapp-controller/docs/latest/package-consumption.md
+++ b/content/kapp-controller/docs/latest/package-consumption.md
@@ -185,8 +185,8 @@ installation.
 ## Installing a package
 
 Once we have the packages available for installation (as seen via `kubectl get
-packages`) we need to let kapp-controller know what we want to install one. To do
-this, we will need to create a PackageInstall CR (and a secret to hold the
+packages`), we need to let kapp-controller know which package we want to install. 
+To do this, we will need to create a PackageInstall CR (and a secret to hold the
 values used by our package):
 
 ```yaml
@@ -218,7 +218,7 @@ This CR references the Package we decided to install in the previous section
 using the package's `refName` and `version` fields. Do note, the `versionSelection`
 property has a `constraints` subproperty to give more control over which
 versions are chosen for installation. More information on PackageInstall versioning
-can be found [here](packaging#versioning-installedpackages).
+can be found [here](packaging#versioning-packageinstalls).
 
 This yaml snippet also contains a Kubernetes secret, which is referenced by the
 PackageInstall. This secret is used to provide customized values to the package


### PR DESCRIPTION
Package Author:
* Remove /config dir for package bundle since it does not align with format used in consumption workflow
* The PackageMetadata CR is not created yet at this point in workflow so change to say it has been saved to file
* Include -y with kapp so users don't get surprised by continue prompt
* Make note to change registry/repo name for creating PackageRepo

Package Consumption:
* Add -y with kapp to avoid any confusion over kapp deploy prompt
* Change version of package shown to 1.0.0 since it is what will be used in PackageInstall

Misc:
* Correct typos
* Fix broken link

External updates outside of this pr:
* Updated example packagerepo/packages since they were using old naming/api definition
