### PR TITLE
Update package def to fit instructions

### DIFF
--- a/site/content/kapp-controller/docs/latest/package-authoring.md
+++ b/site/content/kapp-controller/docs/latest/package-authoring.md
@@ -197,8 +197,7 @@ spec:
       template:
       - ytt:
           paths:
-          - "config.yml"
-          - "values.yml"
+          - "config/"
       - kbld:
           paths:
           - "-"


### PR DESCRIPTION
We updated the instructions to use a config directory in the contents bundle, but missed updating the package definition to fit that structure.