### PR TITLE
docker yml example includes build-args example

### DIFF
--- a/site/content/kbld/docs/latest/config.md
+++ b/site/content/kbld/docs/latest/config.md
@@ -97,7 +97,7 @@ sources:
       pull: true
       noCache: true
       file: "hack/Dockefile.dev"
-      rawOptions: ["--squash"]
+      rawOptions: ["--squash", "--build-arg", "ARG_IN_DOCKERFILE=value"]
 ```
 
 - `docker.build.target` (string): Set the target build stage to build (no default)


### PR DESCRIPTION
it's not obvious whether to pass one string that's `"--build-arg foo=bar"` or two strings `"--build-arg", "foo=bar"` and not trivial to debug since the command run is opaque to the user,  so let's provide an example.