### PR TITLE
Fix typo in kapp docs

### DIFF
--- a/site/content/kapp/docs/latest/config.md
+++ b/site/content/kapp/docs/latest/config.md
@@ -221,7 +221,7 @@ andMatcher:
 ### apiGroupKindMatcher
 
 ```yaml
-apiVersionKindMatcher: {apiGroup: apps, kind: Deployment}
+apiGroupKindMatcher: {apiGroup: apps, kind: Deployment}
 ```
 
 ### apiVersionKindMatcher


### PR DESCRIPTION
Update key in yaml for `apiGroupKindMatcher`