### PR TITLE
Document tagSelection and refSelection for App and PackageRepository

### DIFF
--- a/site/content/kapp-controller/docs/latest/app-spec.md
+++ b/site/content/kapp-controller/docs/latest/app-spec.md
@@ -75,6 +75,16 @@ spec:
           name: secret-name
         # grab only portion of image (optional)
         subPath: inside-dir/dir2
+        # specifies a strategy to choose a tag (optional; v0.24.0+)
+        # if specified, do not include a tag in url key
+        tagSelection:
+          semver:
+            # list of semver constraints (required)
+            constraints: ">1.0.0 <3.0.0"
+            # by default prerelease versions are not included (optional; v0.24.0+)
+            prereleases:
+              # select prerelease versions that include given identifiers (optional; v0.24.0+)
+              identifiers: [beta, rc]
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -84,6 +94,16 @@ spec:
         # secret with auth details (optional)
         secretRef:
           name: secret-name
+        # specifies a strategy to choose a tag (optional; v0.24.0+)
+        # if specified, do not include a tag in url key
+        tagSelection:
+          semver:
+            # list of semver constraints (see https://carvel.dev/vendir/docs/latest/versions/ for details) (required)
+            constraints: ">1.0.0 <3.0.0"
+            # by default prerelease versions are not included (optional; v0.24.0+)
+            prereleases:
+              # select prerelease versions that include given identifiers (optional; v0.24.0+)
+              identifiers: [beta, rc]
 
     # uses http library to fetch file
     - http:
@@ -112,6 +132,15 @@ spec:
         subPath: config-step-2-template
         # skip lfs download (optional)
         lfsSkipSmudge: true
+        # specifies a strategy to resolve to an explicit ref (optional; v0.24.0+)
+        refSelection:
+          semver:
+            # list of semver constraints (see https://carvel.dev/vendir/docs/latest/versions/ for details) (required)
+            constraints: ">0.4.0"
+            # by default prerelease versions are not included (optional; v0.24.0+)
+            prereleases:
+              # select prerelease versions that include given identifiers (optional; v0.24.0+)
+              identifiers: [beta, rc]
 
     # uses helm fetch to fetch specified chart
     - helmChart:

--- a/site/content/kapp-controller/docs/latest/packaging.md
+++ b/site/content/kapp-controller/docs/latest/packaging.md
@@ -183,6 +183,16 @@ spec:
       # Docker image url; unqualified, tagged, or
       # digest references supported (required)
       image: host.com/username/image:v0.1.0
+      # specifies a strategy to choose a tag (optional; v0.24.0+)
+      # if specified, do not include a tag in url key
+      tagSelection:
+        semver:
+          # list of semver constraints (see https://carvel.dev/vendir/docs/latest/versions/ for details) (required)
+          constraints: ">1.0.0 <3.0.0"
+          # by default prerelease versions are not included (optional; v0.24.0+)
+          prereleases:
+            # select prerelease versions that include given identifiers (optional; v0.24.0+)
+            identifiers: [beta, rc]
     # pulls image containing packages from Docker/OCI registry
     image:
       # Image url; unqualified, tagged, or
@@ -190,6 +200,16 @@ spec:
       url: host.com/username/image:v0.1.0
       # grab only portion of image (optional)
       subPath: inside-dir/dir2
+      # specifies a strategy to choose a tag (optional; v0.24.0+)
+      # if specified, do not include a tag in url key
+      tagSelection:
+        semver:
+          # list of semver constraints (see https://carvel.dev/vendir/docs/latest/versions/ for details) (required)
+          constraints: ">1.0.0 <3.0.0"
+          # by default prerelease versions are not included (optional; v0.24.0+)
+          prereleases:
+            # select prerelease versions that include given identifiers (optional; v0.24.0+)
+            identifiers: [beta, rc]
     # uses http library to fetch file containing packages
     http:
       # http and https url are supported;
@@ -209,6 +229,15 @@ spec:
       subPath: config-step-2-template
       # skip lfs download (optional)
       lfsSkipSmudge: true
+      # specifies a strategy to resolve to an explicit ref (optional; v0.24.0+)
+      refSelection:
+        semver:
+          # list of semver constraints (see https://carvel.dev/vendir/docs/latest/versions/ for details) (required)
+          constraints: ">0.4.0"
+          # by default prerelease versions are not included (optional; v0.24.0+)
+          prereleases:
+            # select prerelease versions that include given identifiers (optional; v0.24.0+)
+            identifiers: [beta, rc]
 ```
 
 Example usage:


### PR DESCRIPTION
Added in kapp-controller v0.24.0: https://github.com/vmware-tanzu/carvel-kapp-controller/pull/339

Long term, there should be a section of the Package Consumption docs that mentions that best approach for updating PackageRepositories based on tags, but we should wait until the approach is more clearly defined/receives feedback.