### PR TITLE
Add `http.disableUnpack` to vendir-spec.md

### DIFF
--- a/site/content/vendir/docs/latest/vendir-spec.md
+++ b/site/content/vendir/docs/latest/vendir-spec.md
@@ -71,6 +71,8 @@ directories:
       secretRef:
         # (required)
         name: my-http-auth
+      # disable default behavior to unpack tar, tgz, and zip files (optional)
+      disableUnpack: false
 
     # fetches asset from an image registry (optional; v0.11.0+)
     image:


### PR DESCRIPTION
This is associated with https://github.com/vmware-tanzu/carvel-vendir/pull/104 and should not be merged until 104 is merged and released

Documents additional http.disableUnpack flag to vendir.