### PR TITLE
Include Bazel integration

### DIFF
--- a/site/content/kbld/docs/latest/config.md
+++ b/site/content/kbld/docs/latest/config.md
@@ -4,264 +4,149 @@ title: Configuration
 
 ## Overview
 
-You can configure kbld by adding configuration resources (they follow Kubernetes resource format, but are removed from kbld output). Configuration resources may be specified multiple times.
+Customize how `kbld`:
+- searches for image references,
+- resolves image names,
+- builds images from source, and
+- pushes built images to container registries.
 
-## Schema
+This is done by supplying one or more configuration files. These files are in the Kubernetes resource format (i.e. has `apiVersion` and `kind`). `kbld` consumes and removes such files from its output.
+
+A `kbld` configuration file is structured like so:
 
 ```yaml
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: Config
+minimumRequiredVersion: 0.31.0
 
-minimumRequiredVersion: 0.15.0
+searchRules: ...
+overrides: ...
+sources: ...
+destinations: ...
+```
 
-sources:
-- image: adservice
-  path: src/
+where:
+- `minimumRequiredVersion` (optional; semver) — specifies the minimum required version of `kbld` needed to work with this configuration.
 
-destinations:
-- image: adservice
-  newImage: docker.io/dkalinin/microservices-demo-adservice
+and any combination of the follow four sections:
+- `searchRules` — a list of [Search Rules](#search-rules) that `kbld` follows to locate container image references within the input files.
+- `overrides` — a list of [Overrides](#overrides) that `kbld` applies to found container image references before it attempts to resolve or build the actual image.
+- `sources` — a list of [Sources](#sources), each of which describes where to find the source that makes up the contents of a given image _and_ which build tool to use to construct it.
+- `destinations` — a list of [Destinations](#destinations), each of which describes where (i.e. to which container registry) to publish a given image.
 
+_(Note: prior to v0.28.0, different types of configuration were supplied in different `kind` of files: `kind: Sources`, `kind: ImageDestinations`, `kind: ImageOverrides`, `kind: ImageKeys`. Since v0.28.0, all such configuration can be specified in one kind of file: `kind: Config`; this  is recommended.)_
+
+---
+## Search Rules
+
+`kbld` scans input files for references to container images. Search rules describe how `kbld` should identify those references and how to process them.
+
+A search rule has two parts:
+- conditions for matching (either by key, by value, or both), and
+- a strategy for how to parse and update a matched item.
+
+A search rule is expressed like this:
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+searchRules:
+- keyMatcher: ...
+  valueMatcher: ...
+  updateStrategy: ...
+```
+
+where a rule consists of one or both of the following...
+- `keyMatcher` a [Key Matcher](#key-matcher) — identifies container image references based on an item's key.
+- `valueMatcher` a [Value Matcher](#value-matcher) — identifies container image references based on an item's value.
+ 
+_(If both are specified, their results are "and'ed" together.)_
+
+...and optionally,
+- `updateStrategy` an [Update Strategy](#update-strategy) — what `kbld` should do with the matched container image reference.
+
+**Multiple Matching search rules** \
+If multiple search rules match the same item, the rule that was defined first is applied.
+
+Note: `kbld` includes its own [Default Search Rules](#default-search-rules)
+
+### Key Matcher
+
+Specifies whether a given key indicates that its corresponding value is an image reference.
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
 searchRules:
 - keyMatcher:
-    name: sidecarImage
+    name:
+    path:
+```
+
+where:
+- `name` (string) specifies the key name (e.g. `sidecarImage`)
+- `path` (array) specifies key path from the root of the YAML document.\
+  Each path part can be one of:
+  - the literal key name. (e.g. `[data, sidecarImage]` maps to `data.sidecarImage`)
+  - an array indexing tactic (choose one):
+    - `index:` (int) — search one element in the array at the (zero-based) index given. \
+      (example: `[spec, template, spec, containers, {index: 0}, image]`)
+    - `allIndexes:` (bool) — search all elements in the array. \
+      (example: `[spec, images, {allIndexes: true}]`)
+
+### Value Matcher
+
+Specifies whether a given value contains an image reference.
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+searchRules:
 - valueMatcher:
-    image: exact-image
-    imageRepo: gcr.io/some/repo
-
-overrides:
-- image: nginx
-  newImage: docker.io/library/nginx:1.14.2
+    ( image | imageRepo ):
 ```
+where (choose one):
+- `image` (string) value to match exactly
+- `imageRepo` (string) of values in the format (`[registry]repo[:tag]\[@sha256:...]`), the value of the `repo` portion. \
+  (example: `imageRepo: gcr.io/project/app` \
+  matches `gcr.io/projects/app:v1.1` and `gcr.io/projects/app@sha256:f33e111...` \
+  but not `gcr.io/projects/app_v1`)
 
-- `minimumRequiredVersion` (optional) specify minimume required version of kbld needed to work with this configuration
-- `sources` (optional; array) allows to specify how to build certain images. See details in sections below.
-  - `image` (required; string) image matcher
-  - `path` (required; string) path to source location
-  - `docker` (optional; default) use Docker to build source. [Details](#docker).
-  - `pack` (optional) use pack CLI to build source. [Details](#pack).
-  - `kubectlBuildkit` (optional) use Buildkit CLI for kubectl to build source. [Details](#buildkit-cli-for-kubectl).
-  - `ko` (optional) use `ko` to build source. [Details](#ko).
-- `destinations` (optional; array) allows to specify one or more destination where images should be pushed
-  - `image` (optional) image matcher
-  - `newImage` (optional) image destination (e.g. docker.io/dkalinin/app-demo)
-  - `tags` (optional; array of strings) tags to apply to pushed images (e.g. `[latest, tag2]`) (v0.26.0+)
-- `searchRules` (optional; array) allows to specify one or more matchers for finding image references. Key and value matchers could be specified together or separately. If key and value matchers are specified together, both matchers must succeed. This functionality supersedes `ImageKeys` kind. 
-  - `keyMatcher` (optional) key matcher
-    - `name` (optional; string) specifies key name (e.g. `sidecarImage`)
-    - `path` (optional; array) specifies key path from the root of the YAML document (e.g. `[data, sidecarImage]`, `[spec, images, {allIndexes: true}]`)
-  - `valueMatcher` (optional) value matcher
-    - `image` (optional; string) matches values exactly
-    - `imageRepo` (optional; string) matches values that follow image reference format (`[registry]repo[:tag]\[@sha256:...]`) and expects `repo` portion to match (e.g. `gcr.io/project/app`)
-  - `updateStrategy` (optional) strategy for finding and updating image references within value (v0.21.0+)
-    - `none` (optional) excludes value from processing (v0.22.0+)
-    - `entireString` (optional; default) uses entire value as an image ref
-    - `json` (optional) parses JSON and identifies image refs by specified search rules
-      - `searchRules` ... (recursive)
-    - `yaml` (optional) parses YAML and identifies image refs by specified search rules
-      - `searchRules` ... (recursive)
-- `overrides` (optional; array) configures kbld to rewrite image location before trying to build image or resolve it to a digest.
-  - `image` (optional) image matcher
-  - `newImage` (optional) could be image without tag/digest, image tag ref, or image digest ref
-  - `preresolved` (optional; bool) specifies if `newImage` should be used as is
-  - `tagSelection` (optional; VersionSelection) specifies how to resolve tag for `newImage`. `newImage` in this case is expected to not specify tag or digest (e.g. `gcr.io/my-corp/app`) without a tag. [See `VersionSelection` type details](https://carvel.dev/vendir/docs/latest/versions/#versionselection-type). Available as of v0.28.0+
+### Update Strategy
 
----
-## Sources
-
-Sources configure kbld to execute image building operation based on specified path.
-
-(Note: We recommend using `Config` kind with `sources` key instead of `Sources` kind. `sources` key in both kind `Config` and `Sources` has same functionality.)
-
-Currently supported builders:
-
-- `docker`: [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/) (default)
-- `pack`: [Pack CLI](https://github.com/buildpacks/pack)
-- `kubectlBuildkit`: [BuildKit CLI for kubectl](https://github.com/vmware-tanzu/buildkit-cli-for-kubectl)
-- `ko`: [ko CLI](https://github.com/google/ko)
-
-### Docker
+Given a container image reference identified by one or more matchers, an Update Strategy describes how to update that value (v0.21.0+).
 
 ```yaml
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: Config
-sources:
-- image: image1
-  path: src/
-  docker:
-    # all options shown; none are required
-    build:
-      target: "some-target"
-      pull: true
-      noCache: true
-      file: "hack/Dockefile.dev"
-      rawOptions: ["--squash", "--build-arg", "ARG_IN_DOCKERFILE=value"]
+searchRules:
+- ( keyMatcher | valueMatcher ): ...
+  updateStrategy:
+    yaml:
+      searchRules: ...
+    json:
+      searchRules: ...
+    none: {}
+    entireValue: {}
 ```
 
-- `docker.build.target` (string): Set the target build stage to build (no default)
-- `docker.build.pull` (bool): Always attempt to pull a newer version of the image (default is false)
-- `docker.build.noCache` (bool): Do not use cache when building the image (default is false)
-- `docker.build.file` (string): Name of the Dockerfile (default is Dockerfile)
-- `docker.build.rawOptions` ([]string): Refer to https://docs.docker.com/engine/reference/commandline/build/ for all available options
+where (choose one):
+- `yaml` parses YAML and identifies image refs by specified search rules
+  - `searchRules` — one or more [Search Rules](#search-rules), scoped to the parsed content.
+- `json` parses JSON and identifies image refs by specified search rules
+  - `searchRules` — one or more [Search Rules](#search-rules), scoped to the parsed content.
+- `none` (empty) excludes value from processing (v0.22.0+)
+- `entireValue` (empty; default) uses the exact value as the image reference.
 
-### Pack
+#### Example for `updateStrategy` that parses YAML
 
 ```yaml
 ---
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-sources:
-- image: image1
-  path: src/
-  pack:
-    build:
-      builder: cloudfoundry/cnb:bionic
-```
-
-- `pack.build.builder` (string): Set builder image (required)
-- `pack.build.buildpacks` ([]string): Set list of buildpacks to be used (no default)
-- `pack.build.clearCache` (bool): Clear cache before building image (default is false)
-- `pack.build.rawOptions` ([]string): Refer to `pack build -h` for all available flags
-
-### BuildKit CLI for kubectl
-
-Available as of v0.28.0+
-
-```yaml
----
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-sources:
-- image: image1
-  path: src/
-  kubectlBuildkit:
-    # all options shown; none are required
-    build:
-      target: "some-target"
-      pull: true
-      noCache: true
-      file: "hack/Dockefile.dev"
-      rawOptions: ["--platform=..."]
-```
-
-- `kubectlBuildkit.build.target` (string): Set the target build stage to build (no default)
-- `kubectlBuildkit.build.pull` (bool): Always attempt to pull a newer version of the image (default is false)
-- `kubectlBuildkit.build.noCache` (bool): Do not use cache when building the image (default is false)
-- `kubectlBuildkit.build.file` (string): Name of the Dockerfile (default is Dockerfile)
-- `kubectlBuildkit.build.rawOptions` ([]string): Refer to `kubectl buildkit build -h` for all available options
-
-To provide registry credentials to the builder, create a Kubernetes docker secret:
-
-```
-kubectl create secret docker-registry buildkit --docker-server=https://index.docker.io/v1/ --docker-username=my-user --docker-password=my-password
-```
-
-See project site for details: [buildkit-cli-for-kubectl](https://github.com/vmware-tanzu/buildkit-cli-for-kubectl).
-
-### ko
-
-Available as of v0.28.0+
-
-```yaml
----
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-sources:
-- image: image1
-  path: ./src/
-  ko:
-    build: # all options shown; none are required
-      rawOptions: ["--disable-optimizations"]
-```
-
-- `ko.build.rawOptions` ([]string): Refer to `ko publish -h` for all available options.
-
-  By default `kbld` provides the `--local` flag
-
----
-## Destinations
-
-Destinations configure kbld to push built images to specified location.
-
-Currently images are pushed via Docker daemon for both Docker and pack built images (since pack also uses Docker daemon).
-
-```yaml
----
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-destinations:
-- image: adservice
-  newImage: docker.io/dkalinin/microservices-demo-adservice
-```
-
-As of v0.26.0+, additional tags could be specified to be associated with pushed image (applied via registry API):
-
-```yaml
----
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-destinations:
-- image: adservice
-  newImage: docker.io/dkalinin/microservices-demo-adservice
-  tags:
-  - v0.10.3
-  - latest-staging
-```
-
-### ImageDestinations
-
-We recommend using `Config` kind with `destinations` key instead of `ImageDestinations` kind. `destinations` key in both kind `Config` and `ImageDestinations` has same functionality.
-
----
-## Overrides
-
-Overrides configure kbld to rewrite image location before trying to build it or resolve it to a digest.
-
-```yaml
----
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-overrides:
-- image: unknown
-  newImage: docker.io/library/nginx:1.14.2
-```
-
-It can also hold `preresolved` new image, so no building or resolution happens (for preresolved images, kbld will not connect to registry to obtain any metadata):
-
-```yaml
----
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-overrides:
-- image: unknown
-  newImage: docker.io/library/nginx:1.14.2
-  preresolved: true
-```
-
-`tagSelection` can be used for dynamic selection of a tag based on various strategies. Currently only `semver` strategy is available.
-
-```yaml
----
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-overrides:
-- image: unknown
-  newImage: docker.io/library/nginx
-  tagSelection:
-    semver:
-      constraints: "<1.15.0"
-```
-
-### ImageOverrides
-
-We recommend using `Config` kind with `overrides` key instead of `ImageOverrides` kind. `overrides` key in both kind `Config` and `ImageOverrides` has same functionality.
-
----
-### Example for `updateStrategy` that parses YAML
-
-```yaml
 kind: ConfigMap
 metadata:
   name: config
@@ -283,14 +168,326 @@ searchRules:
           name: image
 ```
 
+Note that in the `ConfigMap`, that `/data/data.yml` holds a multi-line string. That string happens to also be in YAML format. When _that_ YAML is parsed, the `image` key holds a container image reference.
+
+
+### Default Search Rules
+
+After custom search rules have been processed, `kbld` appends the following search rule:
+
+```yaml
 ---
-## Matching images
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+searchRules:
+- keyMatcher:
+    name: image
+  updateStrategy:
+    entireValue: {}
+```
 
-Available as of 0.15.0+
+---
+## Overrides
 
-`Sources`, `ImageDestinations`, and `ImageOverrides` have ability to match images in following ways:
+After `kbld` searches for container image references, it applies a set of "overrides" which effectively rewrite those references. It does this _before_ attempting to build the corresponding image or resolve it to a digest reference.
 
-- via `image` to match exact content
-  - e.g. `image: image1` which would only match `image1`
-- via `imageRepo` to match only by registry+repo combination
-  - e.g. `imageRepo: gcr.io/org/app1` which would match `gcr.io/org/app1:latest` or `gcr.io/org/app1@sha256:...` or just `gcr.io/org/app1`
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+overrides:
+- image:
+  newImage:
+  preresolved:
+  tagSelection: ...
+```
+
+where:
+- `image` (required; string) exact value found while searching for container image references.
+- `newImage` (required; string) value with which to replace/override. This ought to be an image reference in the format `[registry]repo[:tag]\[@sha256:...]`. \
+   Examples:
+  - `nginx`
+  - `quay.io/bitnami/nginx`
+  - `nginx:1.21.1`
+  - `nginx@sha256:a05b0cd...`
+  - `index.docker.io/library/nginx@sha256:a05b0cd...`
+- `preresolved` (optional; bool) specifies if `newImage` should be used as is (rather than be [re]resolved to a digest reference).
+- `tagSelection` (optional; [VersionSelection](https://carvel.dev/vendir/docs/latest/versions/#versionselection-type)) when `newImage` _is_ being resolved, specifies how to select the tag part of the reference before resolving to a digest reference. (Available as of v0.28.0+)
+  - In this case, `newImage` must not have a tag or digest part (e.g. `gcr.io/my-corp/app`).
+
+**Example: Static Rewrite**
+
+With the following configuration, any container image reference of the value `"unknown"` will get rewritten to `"docker.io/library/nginx:1.14.2"` before being resolved to a digest reference.
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+overrides:
+- image: unknown
+  newImage: docker.io/library/nginx:1.14.2
+```
+
+**Example: Preresolved**
+
+This configuration replaces references of `"unknown"` with `"docker.io/library/nginx:1.14.2"`. It short-circuits any building, resolution, or even connecting to a registry to obtain metadata about the image reference.
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+overrides:
+- image: unknown
+  newImage: docker.io/library/nginx:1.14.2
+  preresolved: true
+```
+
+**Example: Dynamic Tag Selection**
+
+This configuration first rewrites references of `"unknown"` with `"docker.io/library/nginx"`. It then queries the registry to locate the latest version just prior to 1.15.0 (which turns out to be 1.14.2).
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+overrides:
+- image: unknown
+  newImage: docker.io/library/nginx
+  tagSelection:
+    semver:
+      constraints: "<1.15.0"
+```
+
+
+---
+## Sources
+
+Rather than resolve an image reference, `kbld` can build the image from source. More precisely, `kbld` can be configured to use one of the many image building tools it integrates with to construct the image from source. For an overview, see [Building Images](building.md).
+
+Such integration is enabled by configuring a "Source":
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+- image: image1
+  path: src/
+  ( docker | pack | kubectlBuildkit | ko | bazel ): ...
+```
+
+where:
+- `image` (required; string) exact value found while searching for container image references.
+- `path` (required; string) filesystem path to the source for the to-be-built image
+- a builder configuration (optional; choose one) — name/configure a specific image builder tool:
+  - `docker:` (default) use [Docker](#docker) to build from source.
+  - `pack:` use [Pack](#pack) to build the image via buildpacks from source.
+  - `kubectlBuildkit:` use [Buildkit CLI for kubectl](#buildkit-cli-for-kubectl) to build the image via a Kubernetes cluster form source.
+  - `ko:` use [ko](#ko) to build the image from Go source.
+  - `bazel:` use [Bazel](#bazel) to build the image via Bazel Container Image Rules.
+  
+
+### Docker
+
+Using this integration requires:
+- Docker — https://docs.docker.com/get-docker
+
+The [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/) must be on the `$PATH`.
+ 
+To configure an image to be built via Docker, include a `docker:`-flavored [Source](#sources):
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+- image: image1
+  path: src/
+  docker:
+    build:
+      target: some-target
+      pull: true
+      noCache: true
+      file: hack/Dockerfile.dev
+      buildkit: true
+      rawOptions: ["--squash", "--build-arg", "ARG_IN_DOCKERFILE=value"]
+```
+where:
+- `target` (string): the target build stage to build (no default)
+- `pull` (bool): always attempt to pull a newer version of the image (default is false)
+- `noCache` (bool): do not use cache when building the image (default is false)
+- `file` (string): name of the Dockerfile (default is Dockerfile)
+- `buildkit` (bool): enable [Builtkit](https://docs.docker.com/develop/develop-images/build_enhancements) for this build.
+- `rawOptions` ([]string): Refer to [`docker build` reference](https://docs.docker.com/engine/reference/commandline/build/) for all available options
+
+### Pack
+
+Using this integration requires:
+- Docker — https://docs.docker.com/get-docker
+- Pack — https://buildpacks.io/docs/tools/pack/
+
+The [Pack CLI](https://buildpacks.io/docs/tools/pack/cli/pack/) must be on the `$PATH`.
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+- image: image1
+  path: src/
+  pack:
+    build:
+      builder: cloudfoundry/cnb:bionic
+```
+where (all options are optional):
+- `builder` (string): Set builder image (required)
+- `buildpacks` ([]string): Set list of buildpacks to be used (no default)
+- `clearCache` (bool): Clear cache before building image (default is false)
+- `rawOptions` ([]string): Refer to `pack build -h` for all available flags
+
+### BuildKit CLI for kubectl
+
+Available as of v0.28.0+
+
+Using this integration requires:
+- `kubectl` — https://kubernetes.io/docs/tasks/tools/
+- Buildkit for kubectl — https://github.com/vmware-tanzu/buildkit-cli-for-kubectl#installing-the-tarball \
+  _(`kbld` v0.28.0+ is tested with buildkit-for-kubectl v0.1.0, but may work well with other versions.)_
+
+The [`kubectl` CLI](https://kubernetes.io/docs/reference/kubectl/kubectl/) must be on the `$PATH`.
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+- image: image1
+  path: src/
+  kubectlBuildkit:
+    build:
+      target: "some-target"
+      pull: true
+      noCache: true
+      file: "hack/Dockefile.dev"
+      rawOptions: ["--platform=..."]
+```
+
+where (all options are optional):
+- `target` (string): Set the target build stage to build (no default)
+- `pull` (bool): Always attempt to pull a newer version of the image (default is false)
+- `noCache` (bool): Do not use cache when building the image (default is false)
+- `file` (string): Name of the Dockerfile (default is Dockerfile)
+- `rawOptions` ([]string): Refer to `kubectl buildkit build -h` for all available options
+
+#### Authenticating to Registry for Pushing Images
+
+To provide registry credentials to the builder, create a Kubernetes `docker-registry` secret:
+
+```
+kubectl create secret docker-registry buildkit --docker-server=https://index.docker.io/v1/ --docker-username=my-user --docker-password=my-password
+```
+
+See project site for details: [buildkit-cli-for-kubectl](https://github.com/vmware-tanzu/buildkit-cli-for-kubectl).
+
+### ko
+
+Available as of v0.28.0+
+
+Using this integration requires:
+- `ko` — https://github.com/google/ko \
+  (`kbld` v0.28.0+ is tested with `ko` v0.8.0, but may work well with other versions.)
+
+The `ko` CLI must be on the `$PATH`.
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+- image: image1
+  path: ./src/
+  ko:
+    build:
+      rawOptions: ["--disable-optimizations"]
+```
+
+where:
+- `rawOptions` (optional; []string): Refer to `ko publish -h` for all available options.
+
+By default `kbld` provides the `--local` flag
+
+### Bazel
+
+Available as of v0.31.0+
+
+Using this integration requires:
+- Docker — https://docs.docker.com/get-docker
+- Bazel — https://docs.bazel.build/versions/main/install.html \
+  _(`kbld` v0.31.0+ is tested with Bazel v4.2.0 and [Container Image Rules](https://github.com/bazelbuild/rules_docker/tree/v0.18.0) v0.18.0,  but may work well with other versions.)_
+
+The `bazel` CLI must be on the `$PATH`.
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+  - image: image1
+    path: ./src/
+    bazel:
+      run:
+        target: :image1-go-container
+        rawOptions: ["--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64"]
+```
+
+where:
+- `target` (string): bazel build target; when passed to `bazel run` will build and load the desired image.
+- `rawOptions` ([]string): Refer to https://docs.bazel.build/versions/main/user-manual.html for all available options.
+
+#### Using Language-specific Container Rules
+
+This integration invokes the `bazel run` command (as opposed to the `bazel build` command). 
+
+Typically, when configuring the Bazel integration with `kbld`, the specified target is one of the [Container Image Rules](https://github.com/bazelbuild/rules_docker/tree/master#bazel-container-image-rules).
+
+With such rules, the `bazel build` command _produces_ the artifacts that make up all images described in the `BUILD`, but stops short of loading any image into the Docker daemon.  In order for an image to be pushed to a registry (i.e. published), it must first be loaded into the local Docker daemon. The `bazel run` command takes that additional step to execute the script that performs that `docker load` _for the named target, only_.
+
+For so-called [`lang_image` rules](https://github.com/bazelbuild/rules_docker/tree/master#language-rules), this also results in launching a container from that image (i.e. `docker run` the built image). For our purposes, this is undesirable because it effectively halts the build.
+
+To skip this that launching step, append the args `-- --norun` via the `rawOptions:` key:
+
+```yaml
+...
+    bazel:
+      run:
+        target: :image1-go-container
+        rawOptions: ["--", "--norun"]
+```
+
+See also https://github.com/bazelbuild/rules_docker#using-with-docker-locally.
+
+---
+## Destinations
+
+Once `kbld` has processed the found container image references (either resolved or built them), it can publish those images to a different registry (on an image-by-image basis).
+
+Pushing images to registries through this configuration requires:
+- Docker — https://docs.docker.com/get-docker
+
+(In the case where all published images are built through [BuildKit CLI for kubectl](#buildkit-cli-for-kubectl), Docker is not required; publishing happens from within the Kubernetes cluster).
+
+Do this by configuring one or more "destinations":
+
+```yaml
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+destinations:
+- image: adservice
+  newImage: docker.io/dkalinin/microservices-demo-adservice
+  tags: [latest, tag2]
+```
+
+where:
+- `image` (required; string) exact value found while searching for container image references.
+- `newImage` (required; string) image destination (i.e. fully qualified registry location for the image)
+- `tags` (optional; array of strings) tags to apply to pushed images (v0.26.0+)


### PR DESCRIPTION
also...
- Decompose overall configuration into individually digestible parts to
  improve readability.
- Fixed some minor omissions/typos.
- Extract note regarding "old school" configuration kinds into a single
  location as a sidebar; new-to-the-tool users are less likely to need
  such a warning.