### PR TITLE
Added Examples for Versioned Annotations

### DIFF
--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -31,7 +31,8 @@ Anytime there is a change to a resource marked as a versioned resource, entirely
 To make resource versioned, add `kapp.k14s.io/versioned` annotation with an empty value. Created resource follow `{resource-name}-ver-{n}` naming pattern by incrementing `n` any time there is a change.
 
 Example:
-```
+```yaml
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -41,7 +42,7 @@ metadata:
 ```
 This will create versioned resource named `secret-sa-sample-ver-1`
 
-```
+```bash
 Namespace  Name                    Kind    Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
 default    secret-sa-sample-ver-1  Secret  -       -    create  -       reconcile  -   -  
 
@@ -52,7 +53,8 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 As of v0.38.0+, You can use `kapp.k14s.io/versioned-keep-original` annotation in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
 
 Example:
-```
+```yaml
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -62,7 +64,7 @@ metadata:
     kapp.k14s.io/versioned-keep-original: ""
 ```
 This will create two resources one with original name `secret-sa-sample` and one with `-ver-{n}` suffix in name `secret-sa-sample-ver-1`.
-```
+```bash
 Namespace  Name                    Kind    Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
 default    secret-sa-sample        Secret  -       -    create  -       reconcile  -   -  
 ^          secret-sa-sample-ver-1  Secret  -       -    create  -       reconcile  -   -  

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -61,7 +61,7 @@ metadata:
     kapp.k14s.io/versioned: ""
     kapp.k14s.io/versioned-keep-original: ""
 ```
-This will create two versioned resource one with original name `secret-sa-sample` and one with `-ver-{n}` suffix in name `secret-sa-sample-ver-1`.
+This will create two resources one with original name `secret-sa-sample` and one with `-ver-{n}` suffix in name `secret-sa-sample-ver-1`.
 ```
 Namespace  Name                    Kind    Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
 default    secret-sa-sample        Secret  -       -    create  -       reconcile  -   -  

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -30,7 +30,46 @@ Anytime there is a change to a resource marked as a versioned resource, entirely
 
 To make resource versioned, add `kapp.k14s.io/versioned` annotation with an empty value. Created resource follow `{resource-name}-ver-{n}` naming pattern by incrementing `n` any time there is a change.
 
+Example:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-sa-sample
+  annotations:
+    kapp.k14s.io/versioned: ""
+```
+This will create versioned resource named `secret-sa-sample-ver-1`
+
+```
+Namespace  Name                    Kind    Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
+default    secret-sa-sample-ver-1  Secret  -       -    create  -       reconcile  -   -  
+
+Op:      1 create, 0 delete, 0 update, 0 noop
+Wait to: 1 reconcile, 0 delete, 0 noop
+```
+
 As of v0.38.0+, You can use `kapp.k14s.io/versioned-keep-original` annotation in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
+
+Example:
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-sa-sample
+  annotations:
+    kapp.k14s.io/versioned: ""
+    kapp.k14s.io/versioned-keep-original: ""
+```
+This will create two versioned resource one with original name `secret-sa-sample` and one with `-ver-{n}` suffix in name `secret-sa-sample-ver-1`.
+```
+Namespace  Name                    Kind    Conds.  Age  Op      Op st.  Wait to    Rs  Ri  
+default    secret-sa-sample        Secret  -       -    create  -       reconcile  -   -  
+^          secret-sa-sample-ver-1  Secret  -       -    create  -       reconcile  -   -  
+
+Op:      2 create, 0 delete, 0 update, 0 noop
+Wait to: 2 reconcile, 0 delete, 0 noop
+```
 
 You can control number of kept resource versions via `kapp.k14s.io/num-versions=int` annotation.
 

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -50,7 +50,7 @@ Op:      1 create, 0 delete, 0 update, 0 noop
 Wait to: 1 reconcile, 0 delete, 0 noop
 ```
 
-As of v0.38.0+, You can use `kapp.k14s.io/versioned-keep-original` annotation in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
+As of v0.38.0+, `kapp.k14s.io/versioned-keep-original` annotation can be used in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
 
 Example:
 ```yaml
@@ -72,7 +72,6 @@ default    secret-sa-sample        Secret  -       -    create  -       reconcil
 Op:      2 create, 0 delete, 0 update, 0 noop
 Wait to: 2 reconcile, 0 delete, 0 noop
 ```
-For `kapp.k14s.io/versioned-keep-original` annotation use case refer to issue [#119](https://github.com/vmware-tanzu/carvel-kapp/issues/119)
 
 You can control number of kept resource versions via `kapp.k14s.io/num-versions=int` annotation.
 

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -70,6 +70,7 @@ default    secret-sa-sample        Secret  -       -    create  -       reconcil
 Op:      2 create, 0 delete, 0 update, 0 noop
 Wait to: 2 reconcile, 0 delete, 0 noop
 ```
+For `kapp.k14s.io/versioned-keep-original` annotation use case refer to issue [#119](https://github.com/vmware-tanzu/carvel-kapp/issues/119)
 
 You can control number of kept resource versions via `kapp.k14s.io/num-versions=int` annotation.
 


### PR DESCRIPTION
Separate examples for both the annotations - 
kapp.k14s.io/versioned: ""
kapp.k14s.io/versioned-keep-original: ""