### PR TITLE
Adding Tanzu Community Edition Packages Reference

### DIFF
--- a/site/content/kapp-controller/_index.html
+++ b/site/content/kapp-controller/_index.html
@@ -57,7 +57,8 @@ title: "kapp-controller"
     <h2>Basic Usages</h2>
     <p>Get more hands on with kapp-controller by watching the demo video below or a more <a href="https://www.youtube.com/watch?v=PmwkicgEKQE">in-depth demo video</a> 
       from our community meeting, taking it for spin through an <a href="https://katacoda.com/carvel/scenarios/kapp-controller-package-management">interactive tutorial</a>, 
-      or <a href="/kapp-controller/docs/latest/packaging-tutorial/">follow the same tutorial</a> with your own Kubernetes cluster.</p>
+      or <a href="/kapp-controller/docs/latest/packaging-tutorial/">follow the same tutorial</a> with your own Kubernetes cluster. You can also get started by installing 
+      packages from <a href="/kapp-controller/docs/latest/package-consumption/#get-started-with-an-oss-package-repository">this OSS Package Repository</a> on your cluster.</p>
     <script src="https://asciinema.org/a/hhZwxyDcXEGiPD9RDHTb3e9QL.js" id="asciicast-hhZwxyDcXEGiPD9RDHTb3e9QL" async></script>
     <p>You can also see a high level overview of kapp-controller's custom resources below and jump into more in depth documentation for 
       each workflow outlined.

--- a/site/content/kapp-controller/docs/latest/package-consumption.md
+++ b/site/content/kapp-controller/docs/latest/package-consumption.md
@@ -282,6 +282,6 @@ metadata:
 spec:
   fetch:
     imgpkgBundle:
-      // Checkout the latest version from Tanzu Community Edition docs
+      # Check out the latest version from Tanzu Community Edition docs
       image: projects.registry.vmware.com/tce/main:0.9.1
 ```

--- a/site/content/kapp-controller/docs/latest/package-consumption.md
+++ b/site/content/kapp-controller/docs/latest/package-consumption.md
@@ -268,3 +268,20 @@ Also remember to cleanup the RBAC created for the PackageInstall:
 ```bash
 $ kapp delete -a default-ns-rbac -y
 ```
+
+## Get Started with an OSS Package Repository
+
+If you want to get started and are looking to install packages on your Kubernetes cluster, checkout the [Packages](https://tanzucommunityedition.io/packages/) in [Tanzu Community Edition](https://tanzucommunityedition.io/). These packages are open sourced and the source code can be found on [GitHub](https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages). You can add the Package Repository to your cluster by creating a PackageRepository CR.
+
+```yaml
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: tce-repo
+spec:
+  fetch:
+    imgpkgBundle:
+      // Checkout the latest version from Tanzu Community Edition docs
+      image: projects.registry.vmware.com/tce/main:0.9.1
+```

--- a/site/content/kapp-controller/docs/latest/package-consumption.md
+++ b/site/content/kapp-controller/docs/latest/package-consumption.md
@@ -271,7 +271,7 @@ $ kapp delete -a default-ns-rbac -y
 
 ## Get Started with an OSS Package Repository
 
-If you want to get started and are looking to install packages on your Kubernetes cluster, checkout the [Packages](https://tanzucommunityedition.io/packages/) in [Tanzu Community Edition](https://tanzucommunityedition.io/). These packages are open sourced and the source code can be found on [GitHub](https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages). You can add the Package Repository to your cluster by creating a PackageRepository CR.
+If you want to get started and are looking to install packages on your Kubernetes cluster, checkout the [Packages](https://tanzucommunityedition.io/packages/) in [Tanzu Community Edition](https://tanzucommunityedition.io/). These are open source packages, and the source code can be found on [GitHub](https://github.com/vmware-tanzu/community-edition/tree/main/addons/packages). You can add the Package Repository to your cluster by creating a PackageRepository CR.
 
 ```yaml
 ---


### PR DESCRIPTION
Adding Tanzu Community Edition Packages reference in our Package Consumption flow. I would like to add a similar note on the kapp-controller landing page as well. 