### PR TITLE
Added Example on configuration rules for Versioned Resources 

### DIFF
--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -52,7 +52,9 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references (since new resource name is not something that configuration author knew about).
 
 <details>
-<summary>Example</summary>
+
+  <summary>Example</summary>
+
 ```yaml
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
@@ -101,7 +103,10 @@ spec:
                   name: special-config
                   key: special.how
 ```
+
+
 Here we have specified the configuration rules that will update the ConfigMap object reference in resources of Kind Deployment. Here `ConfigMap` special-config is marked as versioned so anytime there is an update it will create a new resource with name `special-config-ver-{n}` and update the same name in resource of kind `Deployment` under `configMapKeyRef`. This example is part of [default configuration rule](https://github.com/vmware-tanzu/carvel-kapp/blob/28b17b775558ef4c64ce27a5655b81c00c8a2f59/pkg/kapp/config/default.go#L299) that kapp follows.
+
 </details>
 
 As of v0.38.0+, `kapp.k14s.io/versioned-keep-original` annotation can be used in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -51,10 +51,6 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 
 Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references (since new resource name is not something that configuration author knew about).
 
-<details>
-
-  <summary>Example</summary>
-
 ```yaml
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
@@ -106,8 +102,6 @@ spec:
 
 
 Here we have specified the configuration rules that will update the ConfigMap object reference in resources of Kind Deployment. Here `ConfigMap` special-config is marked as versioned so anytime there is an update it will create a new resource with name `special-config-ver-{n}` and update the same name in resource of kind `Deployment` under `configMapKeyRef`. This example is part of [default configuration rule](https://github.com/vmware-tanzu/carvel-kapp/blob/28b17b775558ef4c64ce27a5655b81c00c8a2f59/pkg/kapp/config/default.go#L299) that kapp follows.
-
-</details>
 
 As of v0.38.0+, `kapp.k14s.io/versioned-keep-original` annotation can be used in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
 

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -100,7 +100,7 @@ spec:
                   name: special-config
                   key: special.how
 ```
-Here we have specified the configuration rules that will update the ConfigMap object reference in resources of Kind Deployment. Here `ConfigMap` is marked as versioned so anytime there is an update it will create a new resource with name `{special-config}-ver-{n}` and update the same name in resource of kind `Deployment` under `configMapKeyRef`.
+Here we have specified the configuration rules that will update the ConfigMap object reference in resources of Kind Deployment. Here `ConfigMap` special-config is marked as versioned so anytime there is an update it will create a new resource with name `special-config-ver-{n}` and update the same name in resource of kind `Deployment` under `configMapKeyRef`. This example is part of [default configuration rule](https://github.com/vmware-tanzu/carvel-kapp/blob/28b17b775558ef4c64ce27a5655b81c00c8a2f59/pkg/kapp/config/default.go#L299) that kapp follows.
 
 As of v0.38.0+, `kapp.k14s.io/versioned-keep-original` annotation can be used in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
 

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -51,7 +51,8 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 
 Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references (since new resource name is not something that configuration author knew about).
 
-Example:
+<details>
+<summary>Example</summary>
 ```yaml
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
@@ -101,6 +102,7 @@ spec:
                   key: special.how
 ```
 Here we have specified the configuration rules that will update the ConfigMap object reference in resources of Kind Deployment. Here `ConfigMap` special-config is marked as versioned so anytime there is an update it will create a new resource with name `special-config-ver-{n}` and update the same name in resource of kind `Deployment` under `configMapKeyRef`. This example is part of [default configuration rule](https://github.com/vmware-tanzu/carvel-kapp/blob/28b17b775558ef4c64ce27a5655b81c00c8a2f59/pkg/kapp/config/default.go#L299) that kapp follows.
+</details>
 
 As of v0.38.0+, `kapp.k14s.io/versioned-keep-original` annotation can be used in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
 

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -50,6 +50,7 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 ```
 
 Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references (since new resource name is not something that configuration author knew about).
+
 Example:
 ```yaml
 apiVersion: kapp.k14s.io/v1alpha1

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -101,9 +101,7 @@ spec:
                   name: special-config
                   key: special.how
 ```
-
 Here we have specified the configuration rules that will update the ConfigMap object reference in resources of Kind Deployment. Here `ConfigMap` special-config is marked as versioned so anytime there is an update it will create a new resource with name `special-config-ver-{n}` and update the same name in resource of kind `Deployment` under `configMapKeyRef`. This example is part of [default configuration rule](https://github.com/vmware-tanzu/carvel-kapp/blob/28b17b775558ef4c64ce27a5655b81c00c8a2f59/pkg/kapp/config/default.go#L299) that kapp follows.
-
 {{< /detail-tag >}}
 
 As of v0.38.0+, `kapp.k14s.io/versioned-keep-original` annotation can be used in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -52,6 +52,7 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references (since new resource name is not something that configuration author knew about).
 
 {{< detail-tag "Example" >}}
+Sample Config
 ```yaml
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -51,6 +51,7 @@ Wait to: 1 reconcile, 0 delete, 0 noop
 
 Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references (since new resource name is not something that configuration author knew about).
 
+{{< detail-tag "Example" >}}
 ```yaml
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
@@ -100,8 +101,9 @@ spec:
                   key: special.how
 ```
 
-
 Here we have specified the configuration rules that will update the ConfigMap object reference in resources of Kind Deployment. Here `ConfigMap` special-config is marked as versioned so anytime there is an update it will create a new resource with name `special-config-ver-{n}` and update the same name in resource of kind `Deployment` under `configMapKeyRef`. This example is part of [default configuration rule](https://github.com/vmware-tanzu/carvel-kapp/blob/28b17b775558ef4c64ce27a5655b81c00c8a2f59/pkg/kapp/config/default.go#L299) that kapp follows.
+
+{{< /detail-tag >}}
 
 As of v0.38.0+, `kapp.k14s.io/versioned-keep-original` annotation can be used in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
 

--- a/site/content/kapp/docs/latest/diff.md
+++ b/site/content/kapp/docs/latest/diff.md
@@ -25,7 +25,7 @@ Related: [rebase rules](config.md/#rebaserules).
 
 In some cases it's useful to represent an update to a resource as an entirely new resource. Common example is a workflow to update ConfigMap referenced by a Deployment. Deployments do not restart their Pods when ConfigMap changes making it tricky for wide variety of applications for pick up ConfigMap changes. kapp provides a solution for such scenarios, by offering a way to create uniquely named resources based on an original resource.
 
-Anytime there is a change to a resource marked as a versioned resource, entirely new resource will be created instead of updating an existing resource. Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references (since new resource name is not something that configuration author knew about).
+Anytime there is a change to a resource marked as a versioned resource, entirely new resource will be created instead of updating an existing resource. 
 
 To make resource versioned, add `kapp.k14s.io/versioned` annotation with an empty value. Created resource follow `{resource-name}-ver-{n}` naming pattern by incrementing `n` any time there is a change.
 
@@ -48,6 +48,58 @@ default    secret-sa-sample-ver-1  Secret  -       -    create  -       reconcil
 Op:      1 create, 0 delete, 0 update, 0 noop
 Wait to: 1 reconcile, 0 delete, 0 noop
 ```
+
+Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references (since new resource name is not something that configuration author knew about).
+Example:
+```yaml
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+templateRules:
+  - resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: v1, kind: ConfigMap}
+    affectedResources:
+      objectReferences:
+        - path: [spec, template, spec, containers, {allIndexes: true}, env, {allIndexes: true}, valueFrom, configMapKeyRef]
+      resourceMatchers:
+  - apiVersionKindMatcher: {apiVersion: apps/v1, kind: Deployment}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: special-config
+  annotations:
+    kapp.k14s.io/versioned: ""
+data:
+  special.how: very-good
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          env:
+            - name: SPECIAL_LEVEL_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: special-config
+                  key: special.how
+```
+Here we have specified the configuration rules that will update the ConfigMap object reference in resources of Kind Deployment. Here `ConfigMap` is marked as versioned so anytime there is an update it will create a new resource with name `{special-config}-ver-{n}` and update the same name in resource of kind `Deployment` under `configMapKeyRef`.
 
 As of v0.38.0+, `kapp.k14s.io/versioned-keep-original` annotation can be used in conjunction with `kapp.k14s.io/versioned` to have the original resource (resource without `-ver-{n}` suffix in name) along with versioned resource.
 


### PR DESCRIPTION
Added example on how Additionally kapp follows configuration rules (default ones, and ones that can be provided as part of application) to find and update object references under Versioned Resources.