### PR TITLE
Reformat ytt Library reference page

### DIFF
--- a/site/content/ytt/docs/latest/lang-ref-ytt-library.md
+++ b/site/content/ytt/docs/latest/lang-ref-ytt-library.md
@@ -2,56 +2,214 @@
 title: Library Module
 ---
 
-## Library annotations
+## Overview
 
-Available in v0.28.0+
+You can extract a whole set of input files (i.e. templates, overlays, data values, etc.) into a "Library".
 
-- `#@library/ref`: Attaches a yaml document to the specified library to be used during evaluation via the library module (only supported for [data value and data value schema documents](ytt-data-values.md#setting-library-values-via-files))
+For example:
 
 ```yaml
-#@library/ref "@app"
-#@data/values-schema
----
-name: "default"
+config/
+├── _ytt_lib/
+│   └── frontend/
+│       ├── schema.yml
+│       └── store.yml
+└── config.yml
 ```
+where:
+- `config/_ytt_lib/frontend/` and its contents is a library named `"frontend"`
+
+Libraries are _not_ automatically included in `ytt` output; one must programmatically load, configure, evaluate, and insert those results into a template that is part of the output.
+
 ```yaml
-#@library/ref "@app"
-#@data/values
----
-name: "app1"
+#! config/config.yml -- example of using a library
+
+#@ load("@ytt:library", "library")
+#@ load("@ytt:template", "template")
+
+#! 1. Load an instance of the library
+#@ app = library.get("frontend")
+
+#! 2. Create a configured copy of the library (does not mutate original)
+#@ app_with_vals = app.with_data_values({"apiDomain": "gateway.example.com"})
+
+#! 3. Evaluate the library and include results (a document set) in the output
+--- #@ template.replace(app_with_vals.eval())
 ```
 
-Note: data values may also be attached to libraries via [command line flags](ytt-data-values.md#setting-library-values-via-command-line-flags)
+For a complete working example, see [ytt-library-module example](/ytt/#example:example-ytt-library-module).
 
-## Library module
+## What is a Library?
 
-Library module `@ytt:library` provides a way to programmatically get result of templates included in a library. Libraries are found within `_ytt_lib` subdirectory.
+A `ytt` library is a directory tree contained within a specially-named directory: [`_ytt_lib/`](lang-ref-load.md#_ytt_lib-directory).
+- The library's _name_ is the path relative from the `_ytt_lib/` directory.
+- The library's _contents_ are those of the directory along with subdirectories, recursively.
+- A library may contain libraries as well, if one of its subdirectories is `_ytt_lib/`.
 
-- `load("@ytt:library", "library")`
+The root directory of a `ytt` invocation is itself a library known as the "root library".
+
+Libraries are evaluated in isolation: each a separate execution of the pipeline described in [How it works](how-it-works.md).
+- Each library has its own data values schema.
+- Overlays within a library only apply over _its_ evaluated document set.
+- The final evaluated result is returned as a [YAML Fragment wrapping a document set.](lang-ref-yaml-fragment.md#yaml-document-set).
+
+---
+
+## Functions
+
+There's but one function in the `@ytt:library` module: [`library.get()`](#libraryget)
+
+### library.get()
+
+Contructs a new [`@ytt:library.instance`](#library-instances) based on the contents from the named library.
+
 ```python
-# build library instance
-app1 = library.get("app")
-
-# build new copy of library with data values (does not mutate app1)
-app1_with_vals = app1.with_data_values({"name": "app1"})
-
-# return results of all YAML templates
-app1_with_vals.eval()
-
-# return url function defined within app library
-url_func = app1_with_vals.export("url")
-url_func() # result of url function
+instance = library.get(name, [<kwargs>])
 ```
 
-- `library.get(name, [alias=, ...])` (`name`: string, returned: library): returns library object that is backed by content under `_ytt_lib/<name>` (found in the same directory as the file containing this call). `name` could contain '/' slashes for directories (e.g. `github.com/k14s/k8s-lib/app`).
-  - Keyword arguments:
-    - `alias=<string>` (no default) can be used to specify unique name for this library instantiation.
-    - `ignore_unknown_comments=<bool>` (default False) equivalent to `ytt --ignore-unknown-comments`. Available v0.31.0+
-      - see [File Marks > type detection for YAML files](file-marks.md#type-detection-for-yaml-files) for more details.
-    - `implicit_map_key_overrides=<bool>` (default False) equivalent to `ytt --implicit-map-key-overrides`. Available v0.31.0+
-    - `strict=<bool>` (default False) equivalent to `ytt --strict`. Available v0.31.0+
-- `x.with_data_values_schema(vals)` (`x`: library, `vals`: dict or YAML fragment, returned: library): returns a new library copy with added data values schema. Given data values schemas are overlayed on top of data values schema found within library. Available v0.35.0+
-- `x.with_data_values(vals)` (`x`: library, `vals`: dict or YAML fragment, returned: library): returns a new library copy with added data values. Given data values are overlayed on top of data values found within library.
+- **`name`** (`string`) — path to the base directory of the desired library: `./_ytt_lib/<name>`. Can contain slashes `/` for sub-directories (e.g. `github.com/vmware-tanzu/carvel-ytt-library-for-kubernetes/app`)
+- keyword arguments (optional):
+  - **`alias=`** (`string`) — unique name for this library instance. See [Aliases](#aliases), below.
+  - **`ignore_unknown_comments=`** (`bool`) — equivalent to `ytt --ignore-unknown-comments`; see [File Marks > type detection for YAML files](file-marks.md#type-detection-for-yaml-files) for more details (default: `False`). (as of v0.31.0)
+  - **`implicit_map_key_overrides=`** (`bool`) — equivalent to `ytt --implicit-map-key-overrides` (default: `False`). (as of v0.31.0)
+  - **`strict=`** (`bool`) — equivalent to `ytt --strict` (default: `False`). (as of v0.31.0)
+- **`instance`** ([`@ytt:library.instance`](#library-instances)) — a new library instance backed by the contents of the named library.
+
+The file containing method invocation must be a sibling of the [`_ytt_lib` directory](lang-ref-load.md#_ytt_lib-directory).
+
+---
+
+## Library Instances
+
+Each library returned from a function within this module is a copy: a separate instance.
+
+A library instance (a value of type `@ytt:library.instance`) is created from source with [`library.get()`](#libraryget).
+
+With a library instance:
+- create configured copies using:
+  - [`instance.with_data_values_schema()`](#instancewith_data_values_schema)
+  - [`instance.with_data_values()`](#instancewith_data_values)
+- evaluate its contents via [`instance.eval()`](#instanceeval)
+- query the contents using:
+  - [`instance.data_values()`](#instancedata_values) for the final data values for the library
+  - [`instance.export()`](#instanceexport) to access its functions and variables
+
+### instance.data_values()
+
+Calculates and returns just the Data Values configured on this library instance.
+
+```python
+dvs = instance.data_values()
+```
+
+- **`dvs`** ([`struct`](lang-ref-structs.md)) — the final data values (i.e. the net result of [all configured data values](ytt-data-values.md#library-data-values)).
+
+### instance.eval()
+
+Calculates the library's final data values (i.e. the net result of [all configured data values](ytt-data-values.md#library-data-values)), evaluates its templates into a document set, and applies its overlays on that document set. Executes the pipeline described in [How it works](how-it-works.md) for its inputs and contents.
+
+```python
+document_set = instance.eval()
+```
+
+- **`document_set`** ([`yamlfragment`](lang-ref-yaml-fragment.md#yaml-document-set)) — the YAML document set resulting from the full evaluation of the library.
+
+### instance.export()
+
+(As of v0.28.0)
+
+Returns the value of an identifier declared within the library instance.
+
+```python
+value = instance.export(name, [path=])
+```
+
+- **`name`** (`string`) — the name of a function or a variable declared within a [module](lang-ref-load.md#terminology) in the library. (i.e. a file with the extension `.lib.yml` or `.star`).
+- **`path=`** (`string`) — the path to the module/file that contains the declaration. Only required when `name` is not unique within the library.
+- **`value`** (any) — a copy of the specified value.
+  - if `value` is a function, it is executed within the context of _its_ library instance.
+
+**Examples:**
+
+_Example 1: Exporting a function from a library._
+
+Assuming some module/file in the "helpers" library contains the definition:
+
+```python
+...
+def wrap_name(name):
+   ...
+end
+...
+```
+
+Can be exported and used from another library:
+
+```python
+helpers = library.get("helpers")
+wrap_name = helpers.export("wrap_name")
+
+full_name = wrap_name("app")
+```
+
+_Example 2: Disambiguating between multiple declarations of function._
+
+Assuming two modules/files in the "helpers" library have the same name:
+
+```python
+# main/funcs.star
+def wrap_name(name): ...
+```
+and
+```python
+# lib/funcs.star
+def wrap_name(name): ...
+```
+
+One of which can be unambiguously referenced:
+
+```python
+helpers = library.get("helpers")
+wrap_name = helpers.export("wrap_name", path="lib/funcs.star")
+
+full_name = wrap_name("app")
+```
+
+Note: without the `path=` keyword argument, `helpers.export()` would report an error.
+
+### instance.with_data_values()
+
+Returns a copy of the library instance with data values overlayed with those given.
+
+```python
+new_instance = instance.with_data_values(dvs, [plain=])
+```
+
+- **`dvs`** (`struct` | [`yamlfragment`](lang-ref-yaml-fragment.md)) — data values with which to overlay (or set, if none exist).
+  - only `yamlfragment`s wrapping a map or an array are supported (i.e. `yamlfragment`s wrapping document sets are not supported)
+  - `yamlfragment` values _can_ contain [overlay annotations](lang-ref-ytt-overlay.md#overlay-annotations) for fine-grained overlay control.
+- **`plain=`** (`bool`) — when `True` indicates that `dvs` should be "plain merged" over existing data values (i.e. the exact same behavior as [`--data-values-file`](https://carvel.dev/ytt/docs/latest/ytt-data-values/#configuring-data-values-via-command-line-flags)).
+  - `dvs` must be plain YAML (i.e. a `struct` or a `yamlfragment` without annotations)
+- **`new_instance`** (`@ytt:library.instance`) — a copy of `instance` with `dvs` overlayed on its data values; `instance` remains unchanged.
+
+### instance.with_data_values_schema()
+
+(As of v0.35.0)
+
+Returns a copy of the library instance with data values schema overlayed with that given.
+
+```python
+new_instance = instance.with_data_values_schema(schema)
+```
+
+- **`schema`** (`struct` | [`yamlfragment`](lang-ref-yaml-fragment.md)) — schema for data values with which to overlay on existing schema (or set if none exist).
+  - only `yamlfragment`s wrapping a map or an array are supported (i.e. `yamlfragment`s wrapping document sets are not supported)
+  - `yamlfragment` values _can_ contain [overlay annotations](lang-ref-ytt-overlay.md#overlay-annotations) for fine-grained overlay control.
+- **`new_instance`** (`@ytt:library.instance`) — a copy of `instance` with a schema updated with `schema`; `instance` remains unchanged.
+
+**Examples:**
+
+_Example 1: Declaring a new data value (and setting it)._
 
 ```yaml
 #@ def app_schema():
@@ -74,22 +232,151 @@ env_vars:
 #@ app1_with_vals = app1.with_data_values(app_vals())
 ```
 
-- `x.eval()` (`x`: library, returned: YAML document set): returns computed YAML document set based on library configuration and data values.
+---
 
-- `x.export(name, [path=])` (`x`: library, `name`: string, `path`: string, returned: any value including function): returns value of a symbol found within a library. Typically used to export a function but could also be used for variables. `path` keyword argument can specify location for the symbol if name is not unique within a library (`path` should not be used unless there are multiple symbols with the same name).
+## Annotations
 
-```python
-url_func = app1_with_vals.export("url", path="config.lib.yml")
+### @library/ref
+
+(As of v0.28.0)
+
+Attaches a YAML document to the specified library. When the library is evaluated, the annotated document is included.
+Only supported on documents annotated with `@data/values` and `@data/values-schema`.
+
+```
+@library/ref library_name
+```
+- **`library_name`** (`string`) — `@`-prefixed path to the base directory of the desired library: `./_ytt_lib/<name>`. Can contain slashes `/` for sub-directories (e.g. `github.com/vmware-tanzu/carvel-ytt-library-for-kubernetes/app`).
+
+**Examples:**
+
+_Example 1: Change default for data value in a library._
+
+```yaml
+#@data/values-schema
+#@library/ref "@frontend"
+---
+name: "custom"
 ```
 
-Available in v0.28.0+
+Overlays the default value for `name` in the "frontend" library to be "custom".
 
-- `x.data_values()` (`x`: library, returned: data values): returns the data values of the library instance.
+_Example 2: Target a data value overlay to a library._
 
-```python
-app_values = app1_with_vals.data_values()
+```yaml
+#@data/values
+#@library/ref "@backend"
+---
+#@overlay/replace
+domains:
+- internal.example.com
+- internal-backup.example.com
 ```
 
-### Examples
+Sets the "backend" library's `domains` data value to be exactly the values given.
 
-See [ytt-library-module example](/ytt/#example:example-ytt-library-module).
+See also: [Data Values > Setting Library Values via Files](ytt-data-values.md#setting-library-values-via-files).
+
+Note: data values may also be attached to libraries via [command line flags](ytt-data-values.md#setting-library-values-via-command-line-flags)
+
+---
+
+## Aliases
+
+To facilitate configuring specific library instances, one can mark them with an alias.
+
+An alias:
+- is defined in a [`library.get()`](#libraryget) call, using the optional `alias=` keyword argument.
+- is added to a library reference by prefixing it with a tilde:
+  - `@~<alias-name>` refers to _any_ library instance with the alias.
+  - `@<library-name>~<alias-name>` refers to _any_ instance of the named library that also has the alias.
+
+For example, given a library known as "fruit":
+
+```
+├── apple-values.yml
+├── config.yml
+├── orange-values.yml
+└── _ytt_lib
+    └── fruit
+        ├── doc.yml
+        └── values.yml
+```
+
+where:
+```yaml
+#! _ytt_lib/fruit/doc.yml
+
+#@ load("@ytt:data", "data")
+--- #@ data.values
+```
+and
+```yaml
+#! _ytt_lib/fruit/values.yml
+
+#@data/values
+---
+variety: ordinary
+poisoned: false
+```
+
+The root library can assign aliases to library instances:
+
+```yaml
+#! ./config.yml
+
+#@ load("@ytt:library", "library")
+
+#@ apple1 = library.get("fruit", alias="apple")
+#@ apple2 = apple1.with_data_values({"variety": "jonamac"})
+
+#@ orange = library.get("fruit", alias="orange")
+
+---
+apple:
+  1: #@ apple1.eval()[0]
+  2: #@ apple2.eval()[0]
+orange: #@ orange.eval()[0]
+```
+
+(note: `apple2` inherits `apple1`'s alias of "apple")
+
+These aliases can be used to target changes to specific library instance(s):
+
+```yaml
+#! ./apple-values.yml
+
+#@data/values
+#@library/ref "@~apple"
+---
+variety: red delicious
+poisoned: true
+```
+
+```yaml
+#! ./orange-values.yml
+
+#@data/values
+#@library/ref "@~orange"
+---
+variety: valencia
+```
+
+When the whole fileset is evaluated, the result is:
+
+```yaml
+apple:
+  1:
+    variety: red delicious
+    poisoned: true
+  2:
+    variety: jonamac
+    poisoned: true
+orange:
+  variety: valencia
+  poisoned: false
+```
+
+notice:
+- only the "@~orange" instance has the variety = "valencia"
+- both "@~apple" library instances are poisoned; while the "orange" instance is not.

--- a/site/content/ytt/docs/latest/ytt-data-values.md
+++ b/site/content/ytt/docs/latest/ytt-data-values.md
@@ -202,14 +202,16 @@ See [Multiple data values example](/ytt/#example:example-multiple-data-values) i
 
 Data values are merged in following order (latter one wins):
 
-- default values from `@data/values-schema` files
-- `@data/values` overlays (same ordering as [overlays](lang-ref-ytt-overlay.md#overlay-order))
-- `--data-values-file` specified files (left to right)
-- `--data-values-env` specified values (left to right)
-- `--data-values-env-yaml` specified values (left to right)
-- `--data-value` specified value (left to right)
-- `--data-value-yaml` specified value (left to right)
-- `--data-value-file` specified value (left to right)
+1. default values from `@data/values-schema` files
+2. `@data/values` overlays (same ordering as [overlays](lang-ref-ytt-overlay.md#overlay-order))
+3. `--data-values-file` specified files (left to right)
+4. `--data-values-env` specified values (left to right)
+5. `--data-values-env-yaml` specified values (left to right)
+6. `--data-value` specified value (left to right)
+7. `--data-value-yaml` specified value (left to right)
+8. `--data-value-file` specified value (left to right)
+
+_(When configuring libraries, the [data values merge order](#library-data-values-merge-order), is the same, even if through different mechanisms.)_
 
 ---
 ## Library data values
@@ -220,7 +222,7 @@ Each library may specify data values which will be evaluated separately from the
 
 ### Setting library values via files
 
-To override library data values, add `@library/ref` annotation to data values YAML document, like so:
+To override library data values, add [`@library/ref`](lang-ref-ytt-library.md#libraryref) annotation to data values YAML document, like so:
 
 ```yaml
 #@library/ref "@lib1"
@@ -254,3 +256,24 @@ ytt -f . \
   --data-values-env-yaml @lib6:YAML_VALS
   --data-values-file @lib6:/path
 ```
+
+### Library Data Values merge order
+
+For a given library instance, data values are merged in following order (latter one wins):
+
+1. default values from schema:
+   1. `@data/values-schema` files within the library
+   2. `@data/values-schema` files [externally referenced in](#setting-library-values-via-files).
+   3. given through [`instance.with_data_values_schema()`](lang-ref-ytt-library.md#instancewith_data_values_schema)
+   4. `@data/values-schema` files [externally referenced in `after_library_module=True`](#setting-library-values-via-files).
+2. values from data value sources:
+   1. `@data/values` overlays within the library (same ordering as [overlays](lang-ref-ytt-overlay.md#overlay-order))
+   2. `@data/values` overlays [externally referenced in](#setting-library-values-via-files)
+   3. specified using [`instance.with_data_values()`](lang-ref-ytt-library.md#instancewith_data_values)
+   4. `@data/values` overlays [externally referenced in `after_library_module=True`](#setting-library-values-via-files)
+   5. `--data-values-file` specified files [referenced in](#setting-library-values-via-command-line-flags) (left to right)
+   6. `--data-values-env` specified values [referenced in](#setting-library-values-via-command-line-flags) (left to right)
+   7. `--data-values-env-yaml` specified values [referenced in](#setting-library-values-via-command-line-flags) (left to right)
+   8. `--data-value` specified value [referenced in](#setting-library-values-via-command-line-flags) (left to right)
+   9. `--data-value-yaml` specified value [referenced in](#setting-library-values-via-command-line-flags) (left to right)
+


### PR DESCRIPTION
- following conventions from Overlays reference page.
- explain what a library is in some detail.
- document creation and use of aliases.
- document library.with_data_values(plain=True).
- enumerate the order in which data values sources apply to libraries.
- refer to the type of libraryValue as "@ytt:library.instance".