### PR TITLE
Add a redirect for a broken doc link

### DIFF
--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -58,3 +58,9 @@ HUGO_ENABLEGITINFO = "true"
   to = "https://carvel.dev/blog/kubecon-na21-keynote-blog/"
   status = 302
   force = true
+
+[[redirects]]
+  from = "https://carvel.dev/kapp-controller/docs/latest/package-authoring"
+  to = "https://carvel.dev/kapp-controller/docs/latest/packaging-tutorial"
+  status = 301
+  force = true


### PR DESCRIPTION
Add redirect for [broken link](https://carvel.dev/kapp-controller/docs/latest/package-authoring)