### PR TITLE
Add note about how kapp treats namespaces

### DIFF
--- a/site/content/kapp-controller/docs/latest/app-spec.md
+++ b/site/content/kapp-controller/docs/latest/app-spec.md
@@ -20,7 +20,7 @@ spec:
   canceled: true
 
   # Deletion requests for the App will result in the App CR being
-  # deleted, but its associated resources will not be deleted 
+  # deleted, but its associated resources will not be deleted
   # (optional; default=false; v0.18.0+)
   noopDelete: true
 
@@ -36,7 +36,8 @@ spec:
   # specifies that app should be deployed to destination cluster;
   # by default, cluster is same as where this resource resides (optional; v0.5.0+)
   cluster:
-    # specifies namespace in destination cluster (optional)
+    # specifies kapp namespace in destination cluster (optional)
+    # see {{< ref "/kapp/docs/latest/state-namespace" >}}
     namespace: ns2
     # specifies secret containing kubeconfig (required)
     kubeconfigSecretRef:


### PR DESCRIPTION
This is potentially confusing to users since an app might specify its own namespace or might not, so users of third-party apps/packages would need to inspect them to determine what effect this config would have.

Fixes https://github.com/vmware-tanzu/carvel-kapp-controller/issues/415