### PR TITLE
kapp controller formatting fix

### DIFF
--- a/site/content/kapp-controller/docs/latest/install.md
+++ b/site/content/kapp-controller/docs/latest/install.md
@@ -23,38 +23,44 @@ appreciate your corrections and contributions to help everyone install
 kapp-controller everywhere.
 
 ### Openshift
+
 1. Explicitly set resource packageinstalls/finalizers for kapp controller cluster role to access (else the kapp controller fails to create packageinstalls).
-```
-kind: ClusterRole
-metadata:
-  name: kapp-controller-cluster-role
-rules:
-- apiGroups:
-  - packaging.carvel.dev
-  resources:
-  ...
-  - packageinstalls/finalizers
-```
-2. Bind the kapp-controller cluster role to a security context constraint that allows uids/gids that kapp deployment uses
+
+    ```
+    kind: ClusterRole
+    metadata:
+      name: kapp-controller-cluster-role
+    rules:
+    - apiGroups:
+      - packaging.carvel.dev
+      resources:
+      ...
+      - packageinstalls/finalizers
+    ```
+
+2. Bind the kapp-controller cluster role to a security context constraint allowing uids/gids that kapp deployment uses
 (currently uid 1000; value given for `runAsUser` in the release.yaml for your
 version of kapp-controller).
-The security context constraint you provide should allow kapp-controller's uid
-to run and should not have root privileges.
-```
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kapp-controller-cluster-role
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - my-nonroot-security-context-contstraint
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
-```
+
+    **Note:** The security context constraint you provide should allow kapp-controller's uid
+    to run and should not have root privileges.
+
+    ```
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kapp-controller-cluster-role
+    rules:
+    - apiGroups:
+      - security.openshift.io
+      resourceNames:
+      - my-nonroot-security-context-contstraint
+      resources:
+      - securitycontextconstraints
+      verbs:
+      - use
+    ```
+
 3. Set the `IMGPKG_ENABLE_IAAS_AUTH` [environment
    variable](https://carvel.dev/imgpkg/docs/latest/auth/#via-iaas) to false.
 

--- a/site/content/kapp-controller/docs/latest/private-registry-auth.md
+++ b/site/content/kapp-controller/docs/latest/private-registry-auth.md
@@ -6,14 +6,14 @@ title: Authenticating to Private Registries
 
 As a package consumer you may need to provide registry credentials if you are consuming package repository (and/or packages) from a registry that requires authenticated access. That may involve providing registry credentials to multiple parts of the system:
 
-1. credentials for pulling package repository bundle (via PackageRepository CR)
+- credentials for pulling package repository bundle (via PackageRepository CR)
     - consumed by imgpkg running inside kapp-controller Pod
-1. credentials for pulling package contents bundle (via PackageInstall CR)
+- credentials for pulling package contents bundle (via PackageInstall CR)
     - consumed by imgpkg running inside kapp-controller Pod
-1. credentials for pulling container images used by the package
+- credentials for pulling container images used by the package
     - credentials consumed by Kubelets
     - e.g. needed by cert-manager controller Pod
-1. credentials for pulling container images used by packages operator
+- credentials for pulling container images used by packages operator
     - credentials consumed by Kubelets
     - e.g. needed by Kafka cluster Pods created for KafkaInstance CR
 
@@ -23,7 +23,7 @@ Note that if you are using an IaaS provided Kubernetes cluster already preauthen
 
 ## secretgen-controller's placeholder secrets and SecretExport CR
 
-For this specific use case, secretgen-controller allows package consumer to specify registry credentials in one namespace and allows to export that secret to the entire cluster (or subset of namespaces) via [SecretExport CR](https://github.com/vmware-tanzu/carvel-secretgen-controller/blob/develop/docs/secret-export.md#secretexport-and-secretrequest). Registry credentials could be consumed in different namespaces via "placeholder secrets". 
+For this specific use case, secretgen-controller allows package consumer to specify registry credentials in one namespace and allows to export that secret to the entire cluster (or subset of namespaces) via [SecretExport CR](https://github.com/vmware-tanzu/carvel-secretgen-controller/blob/develop/docs/secret-export.md#secretexport-and-secretrequest). Registry credentials could be consumed in different namespaces via "placeholder secrets".
 
 A placeholder secret is:
 - plain Kubernetes Secret
@@ -48,7 +48,7 @@ Known limitation: Currently Secrets with type `kubernetes.io/dockerconfigjson` d
 
 As of kapp-controller v0.24.0+, PackageRepository and PackageInstall CRs automatically create placeholder secrets for `image` and `imgpkgBunle` fetch types, if no explicit `secretRef.name` is provided. (These placeholder secrets are named as `<resource-name>-fetch-<i>`.) If secretgen-controller is present on the cluster, these secrets will be populated with combined registry credentials; otherwise, they will remain empty.
 
-## Package authoring and placeholder secrets 
+## Package authoring and placeholder secrets
 
 We encourage all package authors to include placeholder secrets within your package configuration already preconfigured to be used by your Deployments, StatefulSets, DaemonSets, Pods, etc (and any other resources that consume image pull secrets). This removes a need for package consumers to worry about configuring packages in any special way if it's being consumed from a registry that requires authentication. Note that even if you are distributing package repository from a registry that support anonymous access, package consumers may still copy it (via imgpkg copy) into a private registry that does require authentication.
 
@@ -192,7 +192,7 @@ spec:
       # ...
 ```
 
-In the example above, the Package has a single fetch stage to retrieve an imgpkg bundle. To use a PackageInstall 
+In the example above, the Package has a single fetch stage to retrieve an imgpkg bundle. To use a PackageInstall
 to specify what secret to use for this fetch stage, an annotation is added to the PackageInstall as shown below:
 
 ```yaml


### PR DESCRIPTION
Made minor changes to improve the kapp-controller formattings:

- adjust the code indentations
- convert numbered list to bulleted list as numbered list usually indicates the sequence of the items is critical
- move content originally embedded in the step to a separate note section to allow easier reading
- replace repetitive "that" in a single sentence 