### PR TITLE
Carvel ytt Argo CD plugin blog post

### DIFF
--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -1,0 +1,137 @@
+---
+title: "Continuous deployment using the Carvel ytt Argo CD plugin"
+slug: argocd-carvel-plugin
+date: 2022-02-02
+author: Cari Lynn
+excerpt: "Use your favorite Carvel templating tool in your GitOps continuous deployment using the Carvel ytt Argo CD plugin."
+image: /img/logo.svg
+tags: ['ytt', 'argocd', 'gitops']
+---
+
+Argo CD is a declarative, GitOps continuous delivery tool for kubernetes. It follows GitOps philosophy of using Git as a single source of truth for the desired application state. ytt templates are one way you can store desired application state. Here's how you can use ytt templates with Argo CD.
+
+At a high level a deployment using Argo CD starts with a configuration change. A commit with a change is made to the application repository, causing the Argo CD controller to notice the desired state has changed. It processes the manifests from the application repository through built-in templating engines like helm, or what we will be using today, a Carvel Argo CD plugin. Finally, it applies the manifests to the cluster via kubectl.
+
+## You will need these to start your journey:
+- [argocd cli](https://argo-cd.readthedocs.io/en/stable/getting_started/#2-download-argo-cd-cli)
+- kubernetes cluster (I'm using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installing-with-a-package-manager))
+- [kapp](https://github.com/vmware-tanzu/carvel-kapp) or [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- [ytt](https://github.com/vmware-tanzu/carvel-ytt)
+
+## Create the Carvel Plugin
+To make the Carvel plugin available to the application we want to deploy, we need to make a couple patches to the Argo CD cluster configuration. We can do this with ytt overlays!
+
+### Adding carvel-ytt binary to `argocd-repo-server`
+This overlay will copy the binary for ytt to the `argocd-repo-server` pod. Adding this configuration to the existing deployment creates a `initContainer` using an image we publish that contains the Carvel tools. The container copies the ytt binary via volume mounts, as explained further in the [Argo docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/#adding-tools-via-volume-mounts).
+
+```yaml
+#! repo-server-overlay.yml
+#@ load("@ytt:overlay", "overlay")
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"argocd-repo-server"}}), expects=1
+---
+spec:
+  template:
+    spec:
+      #! 1. Define an emptyDir volume which will hold the custom binaries
+      volumes:
+        - name: custom-tools
+          emptyDir: {}
+      #! 2. Use an init container to download/copy custom binaries into the emptyDir
+      initContainers:
+        - name: download-carvel-tools
+          image: index.docker.io/k14s/image@sha256:6ab29951e0207fde6760f6db227f218f20e875f45b22e8ca0ee06c0c8cab32cd
+          command: [sh, -c]
+          args:
+            - cp /usr/local/bin/ytt /custom-tools/ytt
+          volumeMounts:
+            - mountPath: /custom-tools
+              name: custom-tools
+      #! 3. Volume mount the custom binary to the bin directory
+      containers:
+        #@overlay/match by=overlay.subset({"name": "argocd-repo-server"}), expects=1
+        - name: argocd-repo-server
+          volumeMounts:
+            - mountPath: /usr/local/bin/ytt
+              name: custom-tools
+              subPath: ytt
+```
+
+### Make the carvel-ytt plugin available to Applications 
+Expose the plugin by patching the `argocd-cm` ConfigMap's `configManagementPlugins`. The command under `generate` is the command that will be run when using the plugin. 
+
+```yaml
+#! argocd-cm-overlay.yml
+#@ load("@ytt:overlay", "overlay")
+#@overlay/match by=overlay.subset({"kind":"ConfigMap", "metadata":{"name":"argocd-cm"}})
+---
+#@overlay/match missing_ok=True
+data:
+  #! TODO append instead of overwrite this
+  configManagementPlugins: |
+    - name: carvel-ytt
+      generate:                      # Command to generate manifests YAML
+        command: ["sh", "-c"]
+        args: ["ytt -f ."]
+```
+
+### Apply the changes to the cluster
+Since these files need to patch the Argo CD configuration, we can apply the ytt overlay when installing Argo CD directly, or as a separate continuous deployment as an exercise left to the reader.
+
+Now, lets install Argo CD Core. To keep setup simple we are using the core version that does not include the UI. The manifests are available [here](https://argo-cd.readthedocs.io/en/stable/getting_started/#1-install-argo-cd): `https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml`. 
+
+We can run this command to apply the ytt overlays to the Argo CD core manifests, then apply that to the cluster using kapp (or modify for kubectl, if you prefer). The `-y` continues deployment without confirmation. 
+
+```shell
+$ ytt -f argocd-cm-overlay.yml -f  repo-server-overlay.yml -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml  | kapp deploy --app argo --namespace argocd --file - -y
+```
+
+## Create and template an Application with the ytt plugin
+Now, we're going to create an Application resource containing simple ytt templates and data values that watches the git repo directory  `config-step-2-template/`. If you want to see updates automatically deployed when you make changes, fork this repo. Add `spec.source.plugin` to tell Argo to use the ytt plugin. 
+
+```yaml
+# simple-app-application.yml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: simple-app
+  namespace: argocd
+spec:
+  project: default
+  # this sync policy will deploy the app when changes are detected
+  syncPolicy:
+    automated: {}
+  source:
+    repoURL: https://github.com/vmware-tanzu/carvel-simple-app-on-kubernetes.git
+    targetRevision: develop
+    path: config-step-2-template
+
+    # plugin config
+    plugin:
+      name: carvel-ytt
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+```
+Deploy it to the cluster and see that ytt was used to render the templates. 
+```shell
+$ kapp deploy --namespace argocd --app argo-app --file simple-app-application.yml
+```
+Inspect the Application using `argocd` cli
+```shell
+$ argocd login --core
+$ argocd app get simple-app
+```
+For fun, you can view the app at `127.0.0.1:8080`. Visiting the site you should see a message that shows the data values stored in the repository were substituted into the ytt templates properly by the ytt plugin.
+```shell
+$ kubectl port-forward svc/simple-app 8080:80 --namespace default
+```
+
+## Join us on Slack and GitHub
+
+We are excited about this new adventure and we want to hear from you and learn with you. Here are several ways you can get involved:
+
+* Join Carvel's slack channel, [#carvel in Kubernetes]({{% named_link_url "slack_url" %}}) workspace, and connect with over 1000+ Carvel users.
+* Find us on [GitHub](https://github.com/vmware-tanzu/carvel). Suggest how we can improve the project, the docs, or share any other feedback.
+* Attend our Community Meetings, happening every Thursday at 10:30am PT / 1:30pm ET. Check out the [Community page](/community/) for full details on how to attend.
+
+We look forward to hearing from you and hope you join us in building a strong packaging and distribution story for applications on Kubernetes!

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -76,7 +76,7 @@ data:
         command: ["ytt"]
         args: ["-f", "."]
 ```
-Note: Passing a plugin flags like `--data-values-file` is currently not easily doable. See the issue in argocd regarding this for more information, and for a workaround using environment variables.
+Note: Passing a plugin flags like `--data-values-file` is currently not easily doable. See the issue in ArgoCD regarding this for more information, and for a workaround using environment variables.
 
 ### Apply the changes to the cluster
 Since these overlays need to patch the Argo CD configuration, create the namespace and apply the overlays with the Argo CD installation manifests.

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -10,7 +10,7 @@ tags: ['ytt', 'argocd', 'gitops']
 
 Argo CD is a declarative, GitOps, continuous delivery tool for Kubernetes. It's design embraces GitOps philosophy of using Git as a single source of truth for the desired state of the system. In this example we're storing desired application state in ytt templates, and extending Argo CD to template and deploy them.
 
-At a high level a deployment using Argo CD starts with a configuration change. A commit with a change is made to the application repository, causing the Argo CD controller to notice the desired state has changed. It processes the manifests from the application repository through built-in templating engines like helm, or what we will be using: a Carvel ytt Argo CD plugin. Finally, it applies the manifests to the cluster.
+At a high level a deployment using Argo CD starts with a configuration change. A commit with a change is made to the application repository, causing the Argo CD controller to notice the desired state has changed. It processes the manifests from the application repository through built-in templating engines like Helm, or what we will be using: a Carvel ytt Argo CD plugin. Finally, it applies the manifests to the cluster.
 
 ## You will need these to start your journey:
 - [argocd cli](https://argo-cd.readthedocs.io/en/stable/getting_started/#2-download-argo-cd-cli)

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -127,7 +127,7 @@ For fun, you can view the app at `127.0.0.1:8080`. Visiting the site you should 
 $ kubectl port-forward svc/simple-app 8080:80 --namespace default
 ```
 
-## Join us on Slack and GitHub
+## Join the Carvel Community
 
 We are excited about this new adventure and we want to hear from you and learn with you. Here are several ways you can get involved:
 

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: "Continuous deployment using the Carvel ytt Argo CD plugin"
+title: "Continuous deployment using a Carvel ytt Argo CD plugin"
 slug: argocd-carvel-plugin
 date: 2022-02-02
 author: Cari Lynn
@@ -86,7 +86,7 @@ $ ytt -f argocd-cm-overlay.yml -f  repo-server-overlay.yml -f https://raw.github
 ```
 
 ## Create and template an Application with the ytt plugin
-Now, we're going to create an Application resource containing simple ytt templates and data values that watches the git repo directory  `config-step-2-template/`. If you want to see updates automatically deployed when you make changes, fork this repo. Add `spec.source.plugin` to tell Argo to use the ytt plugin. 
+Now, we're going to create an Application resource that watches the git repo directory `config-step-2-template/` containing simple ytt templates and data values. If you want to see updates automatically deployed when you make changes, fork this repo. Add `spec.source.plugin` to tell Argo to use the ytt plugin. 
 
 ```yaml
 # simple-app-application.yml
@@ -118,6 +118,7 @@ $ kapp deploy --namespace argocd --app argo-app --file simple-app-application.ym
 ```
 Inspect the Application using `argocd` cli
 ```shell
+$ kubectl config set-context --current --namespace=argocd
 $ argocd login --core
 $ argocd app get simple-app
 ```

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: "Continuous deployment using a Carvel ytt Argo CD plugin"
+title: "Continuous delivery using a Carvel ytt Argo CD plugin"
 slug: argocd-carvel-plugin
 date: 2022-02-02
 author: Cari Lynn

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -62,14 +62,17 @@ Expose the plugin by patching the `argocd-cm` ConfigMap's `configManagementPlugi
 ```yaml
 #! argocd-cm-overlay.yml
 #@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:yaml", "yaml")
+
 #@overlay/match by=overlay.subset({"kind":"ConfigMap", "metadata":{"name":"argocd-cm"}})
 ---
 #@overlay/match missing_ok=True
 data:
-  #! TODO append instead of overwrite this
+  #! Append to configManagementPlugins
+  #@overlay/replace via=lambda left,right: yaml.encode(overlay.apply(yaml.decode(left), yaml.decode(right)))
   configManagementPlugins: |
     - name: carvel-ytt
-      generate:                      # Command to generate manifests YAML
+      generate:                      #! Command to generate manifests YAML
         command: ["ytt"]
         args: ["-f", "."]
 ```

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -76,7 +76,7 @@ data:
         command: ["ytt"]
         args: ["-f", "."]
 ```
-Note: Passing a plugin flags like `--data-values-file` is currently not easily doable. See the issue in ArgoCD regarding this for more information, and for a workaround using environment variables.
+Note: Passing a plugin flags like `--data-values-file` is currently not easily doable. See the issue in Argo CD regarding this for more information, and for a workaround using environment variables.
 
 ### Apply the changes to the cluster
 Since these overlays need to patch the Argo CD configuration, create the namespace and apply the overlays with the Argo CD installation manifests.

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -22,7 +22,7 @@ At a high level a deployment using Argo CD starts with a configuration change. A
 To make the Carvel plugin available to the application we want to deploy, we need to make a couple patches to the Argo CD cluster configuration. We can do this with ytt overlays!
 
 ### Adding carvel-ytt binary to `argocd-repo-server`
-This overlay will copy the binary for ytt to the `argocd-repo-server` pod. Adding this configuration to the existing deployment creates a `initContainer` using an image we publish that contains the Carvel tools. The container copies the ytt binary via volume mounts, as explained further in the [Argo docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/#adding-tools-via-volume-mounts).
+This overlay will copy the binary for ytt to the `argocd-repo-server` pod. Adding this configuration to the existing deployment creates an `initContainer` using an image we publish that contains the Carvel tools. The container copies the ytt binary via volume mounts, as explained further in the [Argo docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/#adding-tools-via-volume-mounts).
 
 ```yaml
 #! repo-server-overlay.yml

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -171,4 +171,3 @@ We are excited to hear from you and learn with you! Here are several ways you ca
 * Find us on [GitHub](https://github.com/vmware-tanzu/carvel). Suggest how we can improve the project, the docs, or share any other feedback.
 * Attend our Community Meetings, happening every Thursday at 10:30am PT / 1:30pm ET. Check out the [Community page](/community/) for full details on how to attend.
 
-We look forward to hearing from you and hope you join us in building a strong packaging and distribution story for applications on Kubernetes!

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -165,7 +165,7 @@ $ kubectl port-forward svc/simple-app 8080:80 --namespace default
 
 ## Join the Carvel Community
 
-We are excited about this new adventure and we want to hear from you and learn with you. Here are several ways you can get involved:
+We are excited to hear from you and learn with you! Here are several ways you can get involved:
 
 * Join Carvel's slack channel, [#carvel in Kubernetes]({{% named_link_url "slack_url" %}}) workspace, and connect with over 1000+ Carvel users.
 * Find us on [GitHub](https://github.com/vmware-tanzu/carvel). Suggest how we can improve the project, the docs, or share any other feedback.

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -79,7 +79,7 @@ Since these files need to patch the Argo CD configuration, we can apply the ytt 
 
 Now, lets install Argo CD Core. To keep setup simple we are using the core version that does not include the UI. The manifests are available [here](https://argo-cd.readthedocs.io/en/stable/getting_started/#1-install-argo-cd): `https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml`. 
 
-We can run this command to apply the ytt overlays to the Argo CD core manifests, then apply that to the cluster using kapp (or modify for kubectl, if you prefer). The `-y` continues deployment without confirmation. 
+We can run this command to apply the ytt overlays to the Argo CD core manifests and then apply that to the cluster using kapp (or modify for kubectl, if you prefer). The `-y` continues deployment without confirmation. 
 
 ```shell
 $ ytt -f argocd-cm-overlay.yml -f  repo-server-overlay.yml -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml  | kapp deploy --app argo --namespace argocd --file - -y

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -3,7 +3,7 @@ title: "Continuous delivery using a Carvel ytt Argo CD plugin"
 slug: argocd-carvel-plugin
 date: 2022-02-02
 author: Cari Lynn
-excerpt: "Use your favorite Carvel templating tool in your GitOps continuous deployment using the Carvel ytt Argo CD plugin."
+excerpt: "Use your favorite Carvel templating tool in your GitOps continuous delivery using the Carvel ytt Argo CD plugin."
 image: /img/logo.svg
 tags: ['ytt', 'argocd', 'gitops']
 ---

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -8,7 +8,7 @@ image: /img/logo.svg
 tags: ['ytt', 'argocd', 'gitops']
 ---
 
-Argo CD is a declarative, GitOps continuous delivery tool for kubernetes. It follows GitOps philosophy of using Git as a single source of truth for the desired application state. ytt templates are one way you can store desired application state. Here's how you can use ytt templates with Argo CD.
+Argo CD is a declarative, GitOps, continuous delivery tool for kubernetes. It follows the GitOps philosophy of using Git as a single source of truth for the desired application state. ytt templates are one way you can store desired application state. Here's how you can use ytt templates with Argo CD.
 
 At a high level a deployment using Argo CD starts with a configuration change. A commit with a change is made to the application repository, causing the Argo CD controller to notice the desired state has changed. It processes the manifests from the application repository through built-in templating engines like helm, or what we will be using today, a Carvel Argo CD plugin. Finally, it applies the manifests to the cluster via kubectl.
 

--- a/site/content/blog/argocd-carvel-plugin.md
+++ b/site/content/blog/argocd-carvel-plugin.md
@@ -1,7 +1,7 @@
 ---
 title: "Continuous delivery using a Carvel ytt Argo CD plugin"
 slug: argocd-carvel-plugin
-date: 2022-02-02
+date: 2022-02-23
 author: Cari Lynn
 excerpt: "Use your favorite Carvel templating tool in your GitOps continuous delivery using the Carvel ytt Argo CD plugin."
 image: /img/logo.svg
@@ -22,7 +22,7 @@ At a high level a deployment using Argo CD starts with a configuration change. A
 To make the Carvel plugin available to the application we want to deploy, we need to make a couple patches to the Argo CD cluster configuration. We can do this with ytt overlays!
 
 ### Adding carvel-ytt binary to `argocd-repo-server`
-This overlay will copy the binary for ytt to the `argocd-repo-server` pod. Adding this configuration to the existing deployment creates an `initContainer` using an [image](https://github.com/vmware-tanzu/carvel-docker-image) we publish that contains the Carvel tools. The container copies the ytt binary via a shared volume at `/custom-tools`, as explained further in the [Argo docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/#adding-tools-via-volume-mounts).
+This overlay will copy the binary for ytt to the `argocd-repo-server` pod. Adding this configuration to the existing deployment creates an `initContainer` using an [image](https://github.com/vmware-tanzu/carvel-docker-image) we publish that contains the Carvel tools. The container copies the ytt binary via a shared volume at `/custom-tools`, explained further in the [Argo docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/custom_tools/#adding-tools-via-volume-mounts).
 
 ```yaml
 #! repo-server-overlay.yml
@@ -76,6 +76,7 @@ data:
         command: ["ytt"]
         args: ["-f", "."]
 ```
+Note: Passing a plugin flags like `--data-values-file` is currently not easily doable. See the issue in argocd regarding this for more information, and for a workaround using environment variables.
 
 ### Apply the changes to the cluster
 Since these overlays need to patch the Argo CD configuration, create the namespace and apply the overlays with the Argo CD installation manifests.


### PR DESCRIPTION
All feedback has been responded to, I believe we are good to merge this at this point.


Here are the exact commands needed in case you want to create the same environment:
files here: https://github.com/cari-lynn/ytt-argocd-plugin
```shell 
kind create cluster
brew install argocd
kubectl create namespace argocd
ytt -f argocd-cm-overlay.yml -f  repo-server-overlay.yml -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml  | kapp deploy --app argo --namespace argocd --file - -y
kapp deploy --namespace argocd --app argo-app --file simple-app-application.yml
kubectl config set-context --current --namespace=argocd # argocd cli was having issues finding namespace
argocd login --core # to authenticate
argocd app get simple-app  # to see the app status
```