### PR TITLE
Adjusting kbld examples to have images.yml before '-'

### DIFF
--- a/proposals/kapp-controller/003-package-cr-split/README.md
+++ b/proposals/kapp-controller/003-package-cr-split/README.md
@@ -69,8 +69,8 @@ spec:
           - config
       - kbld:
           paths:
-          - -
           - .imgpkg/images.yml
+          - "-"
       deploy:
       - kapp: {}
   valuesSchema:
@@ -133,8 +133,8 @@ spec:
           - config
       - kbld:
           paths:
-          - -
           - .imgpkg/images.yml
+          - "-"
       deploy:
       - kapp: {}
   valuesSchema:

--- a/site/content/kapp-controller/_index.html
+++ b/site/content/kapp-controller/_index.html
@@ -116,8 +116,8 @@ spec:
           - config/
       - kbld:
           paths:
-          - '-'
           - .imgpkg/images.yml
+          - '-'
       deploy:
       - kapp: {}
   valuesSchema:

--- a/site/content/kapp-controller/docs/develop/app-spec.md
+++ b/site/content/kapp-controller/docs/develop/app-spec.md
@@ -213,8 +213,8 @@ spec:
         # lists paths to use explicitly (optional; v0.13.0+)
         # - must be quoted when included with paths
         paths:
-        - "-"
         - .imgpkg/images.yml
+        - "-"
 
     # use helm template command to render helm chart
     - helmTemplate:

--- a/site/content/kapp-controller/docs/develop/packaging-tutorial.md
+++ b/site/content/kapp-controller/docs/develop/packaging-tutorial.md
@@ -285,8 +285,8 @@ spec:
           - "config/"
       - kbld:
           paths:
-          - "-"
           - ".imgpkg/images.yml"
+          - "-"
       deploy:
       - kapp: {}
 EOF

--- a/site/content/kapp-controller/docs/develop/packaging.md
+++ b/site/content/kapp-controller/docs/develop/packaging.md
@@ -77,8 +77,8 @@ spec:
       - kbld:
           paths:
           # - must be quoted when included with paths
-          - "-"
           - .imgpkg/images.yml
+          - "-"
       deploy:
       - kapp: {}
 ```

--- a/site/content/kapp-controller/docs/v0.31.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.31.0/app-spec.md
@@ -215,8 +215,8 @@ spec:
         # lists paths to use explicitly (optional; v0.13.0+)
         # - must be quoted when included with paths
         paths:
-        - "-"
         - .imgpkg/images.yml
+        - "-"
 
     # use helm template command to render helm chart
     - helmTemplate:

--- a/site/content/kapp-controller/docs/v0.31.0/packaging-tutorial.md
+++ b/site/content/kapp-controller/docs/v0.31.0/packaging-tutorial.md
@@ -290,8 +290,8 @@ spec:
           - "config/"
       - kbld:
           paths:
-          - "-"
           - ".imgpkg/images.yml"
+          - "-"
       deploy:
       - kapp: {}
 EOF

--- a/site/content/kapp-controller/docs/v0.31.0/packaging.md
+++ b/site/content/kapp-controller/docs/v0.31.0/packaging.md
@@ -78,8 +78,8 @@ spec:
       - kbld:
           paths:
           # - must be quoted when included with paths
-          - "-"
           - .imgpkg/images.yml
+          - "-"
       deploy:
       - kapp: {}
 ```

--- a/site/content/kapp-controller/docs/v0.32.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.32.0/app-spec.md
@@ -214,8 +214,8 @@ spec:
         # lists paths to use explicitly (optional; v0.13.0+)
         # - must be quoted when included with paths
         paths:
-        - "-"
         - .imgpkg/images.yml
+        - "-"
 
     # use helm template command to render helm chart
     - helmTemplate:

--- a/site/content/kapp-controller/docs/v0.32.0/packaging-tutorial.md
+++ b/site/content/kapp-controller/docs/v0.32.0/packaging-tutorial.md
@@ -286,8 +286,8 @@ spec:
           - "config/"
       - kbld:
           paths:
-          - "-"
           - ".imgpkg/images.yml"
+          - "-"
       deploy:
       - kapp: {}
 EOF

--- a/site/content/kapp-controller/docs/v0.32.0/packaging.md
+++ b/site/content/kapp-controller/docs/v0.32.0/packaging.md
@@ -78,8 +78,8 @@ spec:
       - kbld:
           paths:
           # - must be quoted when included with paths
-          - "-"
           - .imgpkg/images.yml
+          - "-"
       deploy:
       - kapp: {}
 ```

--- a/tutorials/katacoda/kapp-controller-package-management/step07.md
+++ b/tutorials/katacoda/kapp-controller-package-management/step07.md
@@ -63,8 +63,8 @@ spec:
           - "config/"
       - kbld:
           paths:
-          - "-"
           - ".imgpkg/images.yml"
+          - "-"
       deploy:
       - kapp: {}
 EOF


### PR DESCRIPTION
Fixes #259 

Some small README/ documentation adjustment to apply the suggestion change from the issue mentioned above.