### PR TITLE
Add 'path' field for 'fetch' step on AppCR

### DIFF
--- a/site/content/kapp-controller/docs/develop/app-spec.md
+++ b/site/content/kapp-controller/docs/develop/app-spec.md
@@ -64,6 +64,8 @@ spec:
               name: cfgmap-name
               # specifies where to place files found in config map (optional)
               directoryPath: dir
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.0+)
 
     # pulls content from Docker/OCI registry
     - image:

--- a/site/content/kapp-controller/docs/develop/app-spec.md
+++ b/site/content/kapp-controller/docs/develop/app-spec.md
@@ -65,7 +65,7 @@ spec:
               # specifies where to place files found in config map (optional)
               directoryPath: dir
       # Relative path to place the fetched artifacts
-      path: dir (optional; v0.33.0+)
+      path: dir (optional; v0.33.1+)
 
     # pulls content from Docker/OCI registry
     - image:


### PR DESCRIPTION
- Adds new field to allow users to specify a directory to put the fetched artifacts - this opts out of the default integer indexed paths by default
- Relevant issue: https://github.com/vmware-tanzu/carvel-kapp-controller/issues/151