### PR TITLE
Increase discoverability of "ytt overlay primer"

### DIFF
--- a/site/content/ytt/docs/develop/_index.md
+++ b/site/content/ytt/docs/develop/_index.md
@@ -34,7 +34,8 @@ example on the playground
 For more around overlaying...
 - see overlaying in action through a progressive set of examples in [the `ytt` Playground](/ytt/#example:example-match-all-docs);
 - learn more about Overlays in [ytt Overlays overview](ytt-overlays.md);
-- for a reference of all Overlay functionality, see [Overlay module](lang-ref-ytt-overlay.md).
+- for a reference of all Overlay functionality, see [Overlay module](lang-ref-ytt-overlay.md);
+- for a screencast-formatted in-depth introduction to writing and using overlays, watch [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/).
 
 ## Modularizing
 

--- a/site/content/ytt/docs/develop/how-it-works.md
+++ b/site/content/ytt/docs/develop/how-it-works.md
@@ -211,3 +211,4 @@ To learn more about...
     1. go to the [ytt Playground](/ytt/#example:example-match-all-docs)
     2. find the "Overlays" group header, click on it to reveal the group _(you can close the "Basics" group by clicking on it)_.
   - read an introduction at "[Using Overlays](ytt-overlays.md)"
+  - watch [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/) for a screencast-formatted in-depth introduction to writing and using overlays.

--- a/site/content/ytt/docs/develop/lang-ref-ytt-overlay.md
+++ b/site/content/ytt/docs/develop/lang-ref-ytt-overlay.md
@@ -15,9 +15,13 @@ Each modification is composed of:
 - an action (via an [`@overlay/(action)`](#action-annotations) annotation), describing the edit.
 
 Once written, an overlay can be applied in one of two ways:
+- on all rendered templates, [**declaratively**, via YAML documents annotated with `@overlay/match`](#overlays-as-files); this is the most common approach.
+- on selected documents, [**programmatically**, via `overlay.apply()`](#programmatic-access).
 
-- on all rendered templates, [declaratively, via YAML documents annotated with `@overlay/match`](#overlays-as-files); this is the most common approach.
-- on selected documents, [programmatically, via `overlay.apply()`](#programmatic-access).
+Programmatic overlays are applied immediately (while the contained template is being evaluated).
+Declarative overlays are applied in the "Apply Overlays" step as described in [How it works](how-it-works.md).
+
+_(For a step-by-step primer on writing and using overlays, watch [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/).)_
 
 ---
 ## Overlays as files

--- a/site/content/ytt/docs/develop/ytt-overlays.md
+++ b/site/content/ytt/docs/develop/ytt-overlays.md
@@ -73,3 +73,4 @@ contents:
 - [Overlay example](/ytt/#example:example-overlay-files) in the ytt Playground to try it out, yourself.
 - [ytt Library: Overlay module](lang-ref-ytt-overlay.md) for reference of all overlay annotations and functions.
 - [Data Values vs Overlays](data-values-vs-overlays.md) for when to use one mechanism over the other.
+- [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/) for a screencast-formatted in-depth introduction to writing and using overlays.

--- a/site/content/ytt/docs/v0.40.0/_index.md
+++ b/site/content/ytt/docs/v0.40.0/_index.md
@@ -35,7 +35,8 @@ example on the playground
 For more around overlaying...
 - see overlaying in action through a progressive set of examples in [the `ytt` Playground](/ytt/#example:example-match-all-docs);
 - learn more about Overlays in [ytt Overlays overview](ytt-overlays.md);
-- for a reference of all Overlay functionality, see [Overlay module](lang-ref-ytt-overlay.md).
+- for a reference of all Overlay functionality, see [Overlay module](lang-ref-ytt-overlay.md);
+- for a screencast-formatted in-depth introduction to writing and using overlays, watch [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/).
 
 ## Modularizing
 

--- a/site/content/ytt/docs/v0.40.0/how-it-works.md
+++ b/site/content/ytt/docs/v0.40.0/how-it-works.md
@@ -212,3 +212,4 @@ To learn more about...
     1. go to the [ytt Playground](/ytt/#example:example-match-all-docs)
     2. find the "Overlays" group header, click on it to reveal the group _(you can close the "Basics" group by clicking on it)_.
   - read an introduction at "[Using Overlays](ytt-overlays.md)"
+  - watch [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/) for a screencast-formatted in-depth introduction to writing and using overlays.

--- a/site/content/ytt/docs/v0.40.0/lang-ref-ytt-overlay.md
+++ b/site/content/ytt/docs/v0.40.0/lang-ref-ytt-overlay.md
@@ -16,9 +16,13 @@ Each modification is composed of:
 - an action (via an [`@overlay/(action)`](#action-annotations) annotation), describing the edit.
 
 Once written, an overlay can be applied in one of two ways:
+- on all rendered templates, [**declaratively**, via YAML documents annotated with `@overlay/match`](#overlays-as-files); this is the most common approach.
+- on selected documents, [**programmatically**, via `overlay.apply()`](#programmatic-access).
 
-- on all rendered templates, [declaratively, via YAML documents annotated with `@overlay/match`](#overlays-as-files); this is the most common approach.
-- on selected documents, [programmatically, via `overlay.apply()`](#programmatic-access).
+Programmatic overlays are applied immediately (while the contained template is being evaluated).
+Declarative overlays are applied in the "Apply Overlays" step as described in [How it works](how-it-works.md).
+
+_(For a step-by-step primer on writing and using overlays, watch [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/).)_
 
 ---
 ## Overlays as files

--- a/site/content/ytt/docs/v0.40.0/ytt-overlays.md
+++ b/site/content/ytt/docs/v0.40.0/ytt-overlays.md
@@ -74,3 +74,4 @@ contents:
 - [Overlay example](/ytt/#example:example-overlay-files) in the ytt Playground to try it out, yourself.
 - [ytt Library: Overlay module](lang-ref-ytt-overlay.md) for reference of all overlay annotations and functions.
 - [Data Values vs Overlays](data-values-vs-overlays.md) for when to use one mechanism over the other.
+- [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/) for a screencast-formatted in-depth introduction to writing and using overlays.


### PR DESCRIPTION
Given recent feedback about its usefulness for those learning Overlays: https://kubernetes.slack.com/archives/CH8KCCKA5/p1649109481305049?thread_ts=1649104615.457339&cid=CH8KCCKA5
make this primer easier to find by referencing it in a number of places
in the ytt docs.

Apply to both `develop` and `v0.40.0` so that this value-add isn't
dependent on the next release.