### PR TITLE
Add workflow to add new issues and prs to project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,18 @@
+---
+name: Add issues to project
+
+on:
+  issues:
+    types: ['opened']
+  pull_request:
+    types: ['opened']
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/vmware-tanzu/projects/16
+          github-token: ${{ secrets.CARVEL_ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
Leveraging this github action: https://github.com/actions/add-to-project

The secret has not been added to the organization, yet, so it's possible that this fails if merged before the secret is created.