### PR TITLE
ytt playground config boxes can be created and destroyed

### DIFF
--- a/site/content/ytt/js/app.js
+++ b/site/content/ytt/js/app.js
@@ -3,17 +3,19 @@
 
 function NewTemplates(parentEl, templatesOpts) {
   var fileObjects = [];
+  var configBoxesCount = 0;
 
   function resetFiles() {
-    fileObjects = []
+    fileObjects = [];
+    configBoxesCount = 0;
     $(".config-boxes", parentEl).empty();
   }
 
   function addFile(e, opts) { // opts = {text, name, focus}
-    var configId = "config-box-"+fileObjects.length;
+    var configId = "config-box-" + configBoxesCount;
 
     if (!opts.name) {
-      opts.name = "config-" + (fileObjects.length+1) + ".yml";
+      opts.name = "config-" + (configBoxesCount+1) + ".yml";
     }
 
     if (!opts.text) { opts.text = ""; }
@@ -63,6 +65,7 @@ function NewTemplates(parentEl, templatesOpts) {
     });
 
     fileObjects.push(file);
+    configBoxesCount++;
 
     if (opts.focus) {
       file.data.focus();


### PR DESCRIPTION
fixes: https://github.com/vmware-tanzu/carvel-ytt/issues/404

note: this implementation probably limits us to a maximum of only 9007199254740991 config boxes.