### PR TITLE
Add template for contributor role requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/role_request.md
+++ b/.github/ISSUE_TEMPLATE/role_request.md
@@ -1,0 +1,70 @@
+---
+name: Carvel Role Request
+about: Request a role change in the Carvel project
+title: 'REQUEST: Role change for <your-GH-handle>'
+labels: role, community
+---
+
+### Summary
+This issue is a formal request for consideration of a role change in the Carvel project by a member of the community. 
+
+Each role is defined in our contribution model document. If you would like to request mutliple roles / multiple subprojects, 
+please open a new issue for each request.
+
+### GitHub Username
+e.g. (at)example_user
+
+### Role Requested
+- [ ] Reviewer
+- [ ] Approver
+- [ ] Lead
+
+### Applicable Subproject
+- [ ] [carvel-kapp-controller](https://github.com/vmware-tanzu/carvel-kapp-controller)
+- [ ] [carvel-ytt](https://github.com/vmware-tanzu/carvel-ytt)
+- [ ] [carvel-kapp](https://github.com/vmware-tanzu/carvel-kapp)
+- [ ] [carvel-kbld](https://github.com/vmware-tanzu/carvel-kbld)
+- [ ] [carvel-imgpkg](https://github.com/vmware-tanzu/carvel-imgpkg)
+- [ ] [carvel-vendir](https://github.com/vmware-tanzu/carvel-vendir)
+- [ ] [carvel-secretgen-controller](https://github.com/vmware-tanzu/carvel-secretgen-controller)
+- [ ] [kctrl](https://github.com/vmware-tanzu/carvel-kapp-controller/tree/develop/cli)
+
+### General Requirements
+- [ ] I have reviewed the code of conduct (https://github.com/vmware-tanzu/carvel/blob/develop/CODE_OF_CONDUCT.md).
+- [ ] I have enabled 2FA on my GitHub account (https://github.com/settings/security).
+- [ ] I have active participation and provide support (such as GitHub, meetings, Slack, Stack Overflow) in the community for long enough to have demonstrated knowledge and competency (such as 3 months).
+- [ ] I have at least one sponsor (see [current maintainers list](https://github.com/vmware-tanzu/carvel/blob/develop/MAINTAINERS.md)).
+- [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application.
+
+### Role Specific Requirements
+#### [LINK_TO_REVIEWER_DEFINITION] Reviewer
+- [ ] I have reviewed / authored of at least 5 substantial* pull requests to the subproject(s).
+#### [LINK_TO_APPROVER_DEFINITION] Approver
+- [ ] I have reviewed / authored several substantial* pull requests to the codebase.
+- [ ] Demonstrated the ability to plan and execute a track of work.
+#### [LINK_TO_LEAD_DEFINITION] Approver
+- [ ] I have a deep understanding of the technical goals and direction of the subproject.
+- [ ] I have a deep understanding of the domains of the subproject.
+- [ ] I have a deep understanding of the design of the subproject.
+- [ ] I have contributed to the design and direction by doing all of:
+  - [ ] Authoring and reviewing proposals.
+  - [ ] Initiating, contributing and resolving discussions (emails, GitHub issues, meetings).
+  - [ ] Identifying subtle or complex issues in designs and implementation PRs.
+  - [ ] Directly contributed to the subproject through implementation and / or review.
+
+
+### Sponsors
+- @sponsor-1
+- @sponsor-2
+
+### List of contributions to the Carvel subprojects(s)
+#### PRs reviewed / authored
+#### Issues responded to
+#### Projects I am involved with
+
+### Next Steps
+- Once your sponsors have responded with a `+1` for your nomination, your request will be reviewed by the project leads. Any missing information will be requested.
+
+---
+
+> *Substantial is subject to the lead's discretion (e.g. refactors, enhancements rather than grammar correction or trivial pull requests)

--- a/.github/PULL_REQUEST_TEMPLATE/role_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/role_request.md
@@ -6,7 +6,7 @@ labels: role, community
 ---
 
 ### Summary
-This issue is a formal request for consideration of a role change in the Carvel project by a member of the community. 
+This is a formal request for consideration of a role change in the Carvel project by a member of the community. 
 
 Each role is defined in our contribution model document. If you would like to request mutliple roles / multiple subprojects, 
 please open a new issue for each request.


### PR DESCRIPTION
Introduce a new issue template for community members to nominate people for a role change in the Carvel project. 

These roles are based on our upcoming contributor model document.

Signed-off-by: Neil Hickey <nhickey@vmware.com>