### PR TITLE
Fix comment in vendir-spec.md regarding path

### DIFF
--- a/site/content/vendir/docs/develop/vendir-spec.md
+++ b/site/content/vendir/docs/develop/vendir-spec.md
@@ -11,7 +11,7 @@ minimumRequiredVersion: 0.8.0
 
 # one or more directories to manage with vendir
 directories:
-- # path is relative to vendir.yml location
+- # path is relative to `vendir` CLI working directory
   path: config/_ytt_lib
 
   contents:


### PR DESCRIPTION
Before this change, the comment stated:

> path is relative to vendir.yml location

That's not actually true. The path is actually relative to where `vendir` is executed. For example:

- given the following directory layout

  ```
  .
  ├── etc
  │   └── vendir.yml
  ├── opt
  └── src
      └── sub-directory
  ```

- and the following content in `etc/vendir.yml`

  ```yaml
  ---
  apiVersion: vendir.k14s.io/v1alpha1
  kind: Config

  directories:
  - # path is relative to vendir.yml location (NOT TRUE)
    path: ../opt

    contents:
    - path: github.com/vmware-tanzu/carvel

      git:
        url: https://github.com/vmware-tanzu/carvel
        ref: origin/develop
  ```

- and the following shell execution

  ```bash
  cd ./src/sub-directory
  vendir sync --file ../../etc/vendir.yml
  ```

- the Carvel package will end up at `./src/opt/carvel`, when the expectation (based on the comment) would be that it end up in `./opt/carvel`.