### PR TITLE
Introduce shared docs to the website

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -17,6 +17,7 @@ params:
   - imgpkg
   - secretgen-controller
   - vendir
+  - Shared Docs
   search:
     app_id: BSVMS0V37R
   ytt:
@@ -128,6 +129,16 @@ params:
     search: true
     search_index_name: carvel-secretgen-controller
     search_api_key: a38560864c2e9128ae57d5734df438ff
+    versioning: false
+    versions:
+    - develop
+  Shared Docs:
+    name: Shared Docs
+    short_name: shared
+    root_link: /shared/docs/latest/
+    github_url: https://github.com/vmware-tanzu/carvel
+    latest_docs_link: /shared/docs/latest/
+    search: false
     versioning: false
     versions:
     - develop

--- a/site/content/shared/docs/latest/_index.md
+++ b/site/content/shared/docs/latest/_index.md
@@ -7,3 +7,4 @@ cascade:
   type: docs
   layout: docs
 ---
+This documentation pertains to Carvel at a project-level such that these documents are shared across the individual tools.

--- a/site/data/imgpkg/docs/imgpkg-develop-toc.yml
+++ b/site/data/imgpkg/docs/imgpkg-develop-toc.yml
@@ -29,8 +29,14 @@ toc:
     subfolderitems:
       - page: General
         url: /faq-generic
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy
       - page: CA Certs on Windows
         url: /ca-certs-windows
       - page: Debugging

--- a/site/data/imgpkg/docs/imgpkg-v0-32-0-toc.yml
+++ b/site/data/imgpkg/docs/imgpkg-v0-32-0-toc.yml
@@ -29,8 +29,14 @@ toc:
     subfolderitems:
       - page: General
         url: /faq-generic
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy
       - page: CA Certs on Windows
         url: /ca-certs-windows
       - page: Debugging

--- a/site/data/kapp-controller/docs/kapp-controller-develop-toc.yml
+++ b/site/data/kapp-controller/docs/kapp-controller-develop-toc.yml
@@ -65,5 +65,11 @@ toc:
         url: /faq
       - page: kctrl FAQ
         url: /kctrl-faq
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy

--- a/site/data/kapp-controller/docs/kapp-controller-v0-40-0-toc.yml
+++ b/site/data/kapp-controller/docs/kapp-controller-v0-40-0-toc.yml
@@ -65,5 +65,11 @@ toc:
         url: /faq
       - page: kctrl FAQ
         url: /kctrl-faq
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy

--- a/site/data/kapp/docs/kapp-develop-toc.yml
+++ b/site/data/kapp/docs/kapp-develop-toc.yml
@@ -43,5 +43,11 @@ toc:
         url: /faq
       - page: Resource Merge Method
         url: /merge-method
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy

--- a/site/data/kapp/docs/kapp-v0-52-0-toc.yml
+++ b/site/data/kapp/docs/kapp-v0-52-0-toc.yml
@@ -43,5 +43,11 @@ toc:
         url: /faq
       - page: Resource Merge Method
         url: /merge-method
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy

--- a/site/data/kbld/docs/kbld-develop-toc.yml
+++ b/site/data/kbld/docs/kbld-develop-toc.yml
@@ -23,5 +23,11 @@ toc:
         url: /auth
   - title: FAQ
     subfolderitems:
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy

--- a/site/data/kbld/docs/kbld-v0-34-0-toc.yml
+++ b/site/data/kbld/docs/kbld-v0-34-0-toc.yml
@@ -23,5 +23,11 @@ toc:
         url: /auth
   - title: FAQ
     subfolderitems:
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy

--- a/site/data/vendir/docs/vendir-develop-toc.yml
+++ b/site/data/vendir/docs/vendir-develop-toc.yml
@@ -19,5 +19,11 @@ toc:
         url: /github-release
   - title: FAQ
     subfolderitems:
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy

--- a/site/data/vendir/docs/vendir-v0-30-0-toc.yml
+++ b/site/data/vendir/docs/vendir-v0-30-0-toc.yml
@@ -19,5 +19,11 @@ toc:
         url: /github-release
   - title: FAQ
     subfolderitems:
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy

--- a/site/data/ytt/docs/ytt-develop-toc.yml
+++ b/site/data/ytt/docs/ytt-develop-toc.yml
@@ -93,7 +93,13 @@ toc:
         url: /ytt-vs-x
       - page: Schema Migration Guide
         url: /data-values-schema-migration-guide
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy
       - page: Known Limitations
         url: /known-limitations

--- a/site/data/ytt/docs/ytt-v0-42-0-toc.yml
+++ b/site/data/ytt/docs/ytt-v0-42-0-toc.yml
@@ -93,7 +93,13 @@ toc:
         url: /ytt-vs-x
       - page: Schema Migration Guide
         url: /data-values-schema-migration-guide
+      - page: Code of Conduct
+        shared_url: /code-of-conduct
+      - page: Contributing
+        shared_url: /contributing
+      - page: Carvel Development Guidelines
+        shared_url: /development_guidelines
       - page: Security
-        url: /security
+        shared_url: /security-policy
       - page: Known Limitations
         url: /known-limitations

--- a/site/themes/carvel/layouts/docs/_nav.html
+++ b/site/themes/carvel/layouts/docs/_nav.html
@@ -18,6 +18,9 @@
           <li>
             {{ if .github }}
               <a href="{{ $gh }}{{ .url }}" target="_blank">{{ .page }}</a>
+            {{ else if .shared_url}}
+              {{ $url :=  (replace (index (print "/shared/docs/latest" .shared_url "/")) "//" "/")  }}
+              <a href="{{ $url }}" target="_blank">{{ .page }}</a>
             {{ else }}
               {{ $url :=  (replace (index (print "/" $product "/docs/" $version .url "/")) "//" "/")  }}
               <a href="{{ $url }}" {{ if (eq  $.Page.RelPermalink $url) }}class="active"{{ end }}>{{ .page }}</a>


### PR DESCRIPTION
Addressing https://github.com/vmware-tanzu/carvel/issues/58

Changes include:
- Introducing a new Projects dropdown option: Project Docs
- Updating all of the subproject sites to include links to shared documentation for increased visibility/discoverability