### PR TITLE
Explore: a more approachable organization of ytt docs

### DIFF
--- a/site/content/ytt/docs/develop/_index.md
+++ b/site/content/ytt/docs/develop/_index.md
@@ -1,87 +1,29 @@
 ---
-title: "About ytt"
+title: "Welcome"
 cascade:
   version: develop
   toc: "true"
   type: docs
   layout: docs
+toc: "false"
 ---
 
-## Overview
+This is the official documentation for `ytt`. 
 
-`ytt` is a command-line tool used to template and patch YAML files. It also provides the means to collect fragments and piles of YAML into modular chunks for easy re-use.
+The YAML Template Tool is a general-purpose YAML templating and patching utility. While it is an integral part of the [Carvel suite](/), it is equally usable anywhere YAML goes.
 
-In practice, these YAML files are [Kubernetes configuration](https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/), [Concourse Pipeline](https://concourse-ci.org/pipelines.html#schema.pipeline), [Docker Compose](https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file), [GitHub Action workflow](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions) files..., really anything that is in YAML format.
+## Getting Help
 
-`ytt` is most useful when manually maintaining these files has or will become too much work.
+Need some direction? We're here to help!
 
-## Templating
+- Are you trying out `ytt` for the first time? Check out [Getting Started](getting-started.md).
 
-A plain YAML file is turned into a `ytt` template by adding specially formatted comments, that is: annotating. Through these annotations, one can inject input values, logic like conditionals and looping, and perform transformations on the content.
+- Try the [FAQ](faq.md); it has answers to many common questions.
 
-Those "input values" are called "Data Values" in `ytt`. Such inputs are included in a separate file.
+- Doing something specific? Our [Guides]() provide step-by-step walkthroughs.
 
-For more:
-* see it in action in the [load data files](/ytt/#example:example-load-data-values) 
-example on the playground
-* check out the [Using Data Values](how-to-use-data-values.md) guide
-- look up reference details of the programming language used in templates in [Language](lang.md).
+- Need the precise definition of a thing? 
 
-## Patching (aka Overlaying)
+- Can't find the answer elsewhere? Find us on Slack at [#carvel](https://kubernetes.slack.com/archives/CH8KCCKA5) ([invite link](http://slack.k8s.io/))
 
-`ytt` can also be used to patch YAML files. These edits are called "Overlays" and are themselves written in YAML.
-
-For more around overlaying...
-- see overlaying in action through a progressive set of examples in [the `ytt` Playground](/ytt/#example:example-match-all-docs);
-- learn more about Overlays in [ytt Overlays overview](ytt-overlays.md);
-- for a reference of all Overlay functionality, see [Overlay module](lang-ref-ytt-overlay.md);
-- for a screencast-formatted in-depth introduction to writing and using overlays, watch [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/).
-
-## Modularizing
-
-`ytt` provides powerful techniques for extracting and reusing chunks of YAML and logic.
-
-Functions in `ytt` capture either a calculation or fragment of YAML. Functions can be used in the same templates that define them, or — if defined in a module file — loaded into any template. Entire sets of templates, overlays, and library code can be encapsulated in a `ytt` library.
-
-For more about modular code...
-- see live examples in the `ytt` Playground around [functions](ytt/#example:example-function) and [`ytt` libraries](/ytt/#example:example-ytt-library-module);
-- read further about [functions](lang-ref-def.md), [YAML Fragments](lang-ref-yaml-fragment.md), and [loading reusable modules and libraries](lang-ref-load.md);
-- catch-up on a particularly relevant [discussion about using modules and libraries in `ytt`](https://github.com/vmware-tanzu/carvel-ytt/discussions/392#discussioncomment-766445).
-
-## Further Reading
-
-Hopefully, the pointers above helped get you started. If you're looking to go either deeper or broader, here are some resources we can recommend.
-
-### Documentation
-
-- [How it Works](how-it-works.md) \
-  _a more detailed look of how all these parts fit together._
-  
-- [ytt vs. X](ytt-vs-x.md) \
-  _how `ytt` differs from similar tools._
-
-### Articles
-
-- [ytt: The YAML Templating Tool that simplifies complex configuration management](https://developer.ibm.com/blogs/yaml-templating-tool-to-simplify-complex-configuration-management/) \
-  _a complete introduction of `ytt` including motivations and contrasts with other tools._
-  
-- [Deploying Kubernetes Applications with ytt, kbld, and kapp](/blog/deploying-apps-with-ytt-kbld-kapp) \
-  _how `ytt` works well with other Carvel tools._
-
-### Presentations and Interviews
-
-- IBM Developer podcast: [Introducing the YAML Templating Tool (ytt)](https://www.youtube.com/watch?v=KbB5tI_g3bo) \
-  _a thorough introduction to `ytt` especially contrasted with Helm._
-  
-- TGI Kubernetes: [#079: YTT and Kapp](https://www.youtube.com/watch?v=CSglwNTQiYg) \
-  _Joe Beda puts both `ytt` and sister tool `kapp` through their paces._
-  
-- Helm Summit 2019: [ytt: An Alternative to Text Templating of YAML Configuration in Helm](https://www.youtube.com/watch?v=7-PqgpkxC7E)
-  ([slides](https://github.com/k14s/meetups/blob/develop/ytt-2019-sep-helm-summit.pdf)) \
-  _in-depth review of the philosophy behind `ytt` and how it differs from other YAML templating approaches._
-  
-- Kubecon 2020: [Managing Applications in Production: Helm vs ytt & kapp @ Kubecon 2020](https://www.youtube.com/watch?v=WJw1MDFMVuk) \
-  _how `ytt` and `kapp` can provide an alternative way to manage the lifecycle of application on Kubernetes._
-  
-- Rawkode Live: [Introduction to Carvel](https://www.youtube.com/watch?v=LBCmMTofNxw) \
-  _Dmitriy joins David McKay to talk through many tools in the Carvel suite, including `ytt`._
+- Suspect you found a bug? Please [report it](https://github.com/vmware-tanzu/carvel-ytt/issues/new?assignees=&labels=bug%2C+carvel+triage&template=bug-report.md&title=).

--- a/site/content/ytt/docs/develop/about.md
+++ b/site/content/ytt/docs/develop/about.md
@@ -1,0 +1,87 @@
+---
+title: "About ytt"
+cascade:
+  version: develop
+  toc: "true"
+  type: docs
+  layout: docs
+---
+
+## Overview
+
+`ytt` is a command-line tool used to template and patch YAML files. It also provides the means to collect fragments and piles of YAML into modular chunks for easy re-use.
+
+In practice, these YAML files are [Kubernetes configuration](https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/), [Concourse Pipeline](https://concourse-ci.org/pipelines.html#schema.pipeline), [Docker Compose](https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file), [GitHub Action workflow](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions) files..., really anything that is in YAML format.
+
+`ytt` is most useful when manually maintaining these files has or will become too much work.
+
+## Templating
+
+A plain YAML file is turned into a `ytt` template by adding specially formatted comments, that is: annotating. Through these annotations, one can inject input values, logic like conditionals and looping, and perform transformations on the content.
+
+Those "input values" are called "Data Values" in `ytt`. Such inputs are included in a separate file.
+
+For more:
+* see it in action in the [load data files](/ytt/#example:example-load-data-values) 
+example on the playground
+* check out the [Using Data Values](how-to-use-data-values.md) guide
+- look up reference details of the programming language used in templates in [Language](lang.md).
+
+## Patching (aka Overlaying)
+
+`ytt` can also be used to patch YAML files. These edits are called "Overlays" and are themselves written in YAML.
+
+For more around overlaying...
+- see overlaying in action through a progressive set of examples in [the `ytt` Playground](/ytt/#example:example-match-all-docs);
+- learn more about Overlays in [ytt Overlays overview](ytt-overlays.md);
+- for a reference of all Overlay functionality, see [Overlay module](lang-ref-ytt-overlay.md);
+- for a screencast-formatted in-depth introduction to writing and using overlays, watch [Primer on `ytt` Overlays](/blog/primer-on-ytt-overlays/).
+
+## Modularizing
+
+`ytt` provides powerful techniques for extracting and reusing chunks of YAML and logic.
+
+Functions in `ytt` capture either a calculation or fragment of YAML. Functions can be used in the same templates that define them, or — if defined in a module file — loaded into any template. Entire sets of templates, overlays, and library code can be encapsulated in a `ytt` library.
+
+For more about modular code...
+- see live examples in the `ytt` Playground around [functions](ytt/#example:example-function) and [`ytt` libraries](/ytt/#example:example-ytt-library-module);
+- read further about [functions](lang-ref-def.md), [YAML Fragments](lang-ref-yaml-fragment.md), and [loading reusable modules and libraries](lang-ref-load.md);
+- catch-up on a particularly relevant [discussion about using modules and libraries in `ytt`](https://github.com/vmware-tanzu/carvel-ytt/discussions/392#discussioncomment-766445).
+
+## Further Reading
+
+Hopefully, the pointers above helped get you started. If you're looking to go either deeper or broader, here are some resources we can recommend.
+
+### Documentation
+
+- [How it Works](how-it-works.md) \
+  _a more detailed look of how all these parts fit together._
+  
+- [ytt vs. X](ytt-vs-x.md) \
+  _how `ytt` differs from similar tools._
+
+### Articles
+
+- [ytt: The YAML Templating Tool that simplifies complex configuration management](https://developer.ibm.com/blogs/yaml-templating-tool-to-simplify-complex-configuration-management/) \
+  _a complete introduction of `ytt` including motivations and contrasts with other tools._
+  
+- [Deploying Kubernetes Applications with ytt, kbld, and kapp](/blog/deploying-apps-with-ytt-kbld-kapp) \
+  _how `ytt` works well with other Carvel tools._
+
+### Presentations and Interviews
+
+- IBM Developer podcast: [Introducing the YAML Templating Tool (ytt)](https://www.youtube.com/watch?v=KbB5tI_g3bo) \
+  _a thorough introduction to `ytt` especially contrasted with Helm._
+  
+- TGI Kubernetes: [#079: YTT and Kapp](https://www.youtube.com/watch?v=CSglwNTQiYg) \
+  _Joe Beda puts both `ytt` and sister tool `kapp` through their paces._
+  
+- Helm Summit 2019: [ytt: An Alternative to Text Templating of YAML Configuration in Helm](https://www.youtube.com/watch?v=7-PqgpkxC7E)
+  ([slides](https://github.com/k14s/meetups/blob/develop/ytt-2019-sep-helm-summit.pdf)) \
+  _in-depth review of the philosophy behind `ytt` and how it differs from other YAML templating approaches._
+  
+- Kubecon 2020: [Managing Applications in Production: Helm vs ytt & kapp @ Kubecon 2020](https://www.youtube.com/watch?v=WJw1MDFMVuk) \
+  _how `ytt` and `kapp` can provide an alternative way to manage the lifecycle of application on Kubernetes._
+  
+- Rawkode Live: [Introduction to Carvel](https://www.youtube.com/watch?v=LBCmMTofNxw) \
+  _Dmitriy joins David McKay to talk through many tools in the Carvel suite, including `ytt`._

--- a/site/content/ytt/docs/develop/faq.md
+++ b/site/content/ytt/docs/develop/faq.md
@@ -2,6 +2,116 @@
 title: FAQ
 ---
 
+## Sticking Points
+
+`ytt` has some rough edges. 
+
+Answers in this section aim to soften the most common:
+
+### When is there a space after the `#@`?
+
+### 
+
+
+### What's the difference between a dictionary (dict), YAML Fragment, and a struct?
+- https://kubernetes.slack.com/archives/CH8KCCKA5/p1661866059223099
+
+
+## Error Messages
+
+### `Expected number of matched nodes to be 1, but was 0`
+
+```console
+ytt: Error: Overlaying data values (in following order: values.yaml):
+  Document on line values.yaml:2:
+    Map item (key 'accounts') on line fake-values.yaml:117:
+      Expected number of matched nodes to be 1, but was 0
+```
+
+### `got identifier, want ')'`
+
+```console
+ytt: Error:
+- got identifier, want ')'
+  template.yaml:3 | name: #@ data.values.name  #! name goes here
+```
+
+Known issue: https://github.com/vmware-tanzu/carvel-ytt/issues/668
+
+
+### `struct has no (field-name) field or method`
+
+```console
+ytt: Error:
+- struct has no .replica field or method
+```
+
+---
+
+### `undefined: data`
+
+This error message comes up in a couple of common situations...
+
+**Possible missing `load("@ytt:data", "data")`**
+
+This can commonly happen when attempting to reference a Data Value:
+
+```console
+ytt: Error:
+- undefined: data
+    template.yaml:2 | name: #@ data.values.name
+```
+
+Was the `@ytt:data` module loaded at the top of the template?
+
+```yaml
+#@ load("@ytt:data", "data")
+---
+name: #@ data.values.name
+```
+_(the `load()` statement imports the `@ytt:data` module into the variable `data`)_
+
+For the gory details see [Load](lang-ref-load.md).
+
+...
+
+**Extra space in an annotation**
+
+```console
+ytt: Error:
+- undefined: data
+    schema.yaml:1 | #@ data/values-schema
+```
+
+Does the annotation have a space in the name?
+
+Annotations (like `@data/values`, `@data/values-schema`, `@overlay/match`, etc.) do not have a leading space:
+
+```yaml
+#@data/values-schema
+---
+name: foo
+```
+
+See also [When is there a space after the `#@`?](#when-is-there-a-space-after-the-).
+
+
+---
+
+### `yamlfragment has no (field-name) field or method`
+
+```console
+ytt: Error: 
+- yamlfragment has no .pinniped field or method
+```
+
+
+## Getting Things Done
+
+### How do I create and use utility/helper/common libraries?
+- https://kubernetes.slack.com/archives/CH8KCCKA5/p1662024350242189
+
+
 ## Data Values
 
 [Data values doc](ytt-data-values.md)

--- a/site/content/ytt/docs/develop/getting-started.md
+++ b/site/content/ytt/docs/develop/getting-started.md
@@ -1,0 +1,74 @@
+---
+title: Getting Started
+toc: "true"
+---
+
+## 
+
+
+basically, YAML with Python*
+
+example template
+
+```yaml
+#@ app = "frontend"
+---
+metadata:
+  name: #@ app + "-service"
+```
+
+YAML as in this is a real YAML document with comments
+
+ignoring the comments:
+
+```yaml
+---
+metadata:
+  name: null
+```
+
+ytt reads the comments as code
+so a variable `app` is set to the string `"frontend"`
+and the value for `name:` gets set to `app + "-service"`.
+
+when evaluated,
+```yaml
+---
+metadata:
+  name: frontend-service
+```
+
+Flow control weaves _into_ the YAML:
+
+```yaml
+#@ debug = False
+#@ app = "frontend"
+---
+metadata:
+  name: #@ app + "-service"
+spec:
+  #@ if debug:
+  logLevel: trace
+  #@ end
+  containers:
+    #@ for img in ["nginx", "redis"]
+    - name: #@ img
+      image: #@ img + ":latest"
+    #@ end
+```
+
+since `debug` is `False` (note Python*'s literal for false has a capital 'F'), `logLevel:` won't be included in the evaluated doc.
+and our `for` loop iterates over that list containing two strings, producing two items.
+
+```yaml
+---
+metadata:
+  name: frontend-service
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+    - name: redis
+      image: redis:latest
+```
+

--- a/site/data/ytt/docs/ytt-develop-toc.yml
+++ b/site/data/ytt/docs/ytt-develop-toc.yml
@@ -1,14 +1,18 @@
 toc:
   - title: Introduction
     subfolderitems:
-      - page: About ytt
+      - page: Welcome
         url: /
       - page: Install
         url: /install
-      - page: How it Works
-        url: /how-it-works
+      - page: Getting Started
+        url: /getting-started
   - title: Concepts
     subfolderitems:
+      - page: About ytt
+        url: /about
+      - page: How it Works
+        url: /how-it-works
       - page: YAML and Annotations
         url: /yaml-primer
   - title: Quick References


### PR DESCRIPTION
After getting some pointed feedback about how difficult it is to approach ytt, exploring some pointed ways to improve the on-ramp.

So far:
- a Welcome page with a concierge-style greeting
- a section in the FAQs where the title of the FAQ is a common error message (troubleshooting guide, essentially)
- ...