### PR TITLE
Enumerate Playground examples in an index page

### DIFF
--- a/site/content/ytt/docs/develop/index-playground-examples.md
+++ b/site/content/ytt/docs/develop/index-playground-examples.md
@@ -1,0 +1,159 @@
+---
+title: Playground Examples Index
+---
+
+## Basics
+
+### How Plain YAML is parsed
+
+https://carvel.dev/ytt/#example:example-plain-yaml
+
+### Datatypes in Starlark are encoded in YAML
+
+https://carvel.dev/ytt/#example:example-datatypes
+
+### Local variables within a template
+
+https://carvel.dev/ytt/#example:example-variable
+
+### Surrounding YAML with an if statement
+
+https://carvel.dev/ytt/#example:example-if
+
+### Looping or Generating YAML with a for loop
+
+https://carvel.dev/ytt/#example:example-for
+
+### Making a mini-template or extracting a chunk of YAML using a function
+
+https://carvel.dev/ytt/#example:example-function
+
+### Including helper functions from another file using load()
+
+https://carvel.dev/ytt/#example:example-load
+
+### Encoding or hashing a string
+
+https://carvel.dev/ytt/#example:example-load-ytt-library-module
+
+### Including a function from a library
+
+https://carvel.dev/ytt/#example:example-load-custom-library-module
+
+### Asserting on a particular value or condition
+
+https://carvel.dev/ytt/#example:example-assert
+
+### Declaring and using Data Values
+
+https://carvel.dev/ytt/#example:example-load-data-values
+
+### Loading and including data from a text or CSV file
+
+https://carvel.dev/ytt/#example:example-load-data-files
+
+### Templating strings and key names using text templating
+
+https://carvel.dev/ytt/#example:example-text-template
+
+### Inserting a YAML fragment or a value using template.replace()
+
+https://carvel.dev/ytt/#example:example-replace
+
+### Modifying or editing a YAML fragment with an overlay
+
+https://carvel.dev/ytt/#example:example-overlay
+
+### Writing an overlay that applies over all the other documents
+
+https://carvel.dev/ytt/#example:example-overlay-files
+
+### Splitting data values into multiple files
+
+https://carvel.dev/ytt/#example:example-multiple-data-values
+
+### Grouping and using multiple templates as a set using libraries
+
+https://carvel.dev/ytt/#example:example-ytt-library-module
+
+### Simple Kubernetes example with a Pod and a Service
+
+https://carvel.dev/ytt/#example:example-k8s-ingress-single
+
+### Kubernetes example producing multiple applications from data values
+
+https://carvel.dev/ytt/#example:example-k8s-ingress-multiple
+
+### Helm Chart like output from ytt
+
+https://carvel.dev/ytt/#example:example-k8s-helm-ish
+
+### A complete working example of many ytt features
+
+https://carvel.dev/ytt/#example:example-demo
+
+## Overlays
+
+### Overlay matching on all documents
+
+https://carvel.dev/ytt/#example:example-match-all-docs
+
+### Overlay matching on specific documents
+
+https://carvel.dev/ytt/#example:example-match-subset-docs
+
+### Overlay matching on specific documents using a YAML Fragment
+
+https://carvel.dev/ytt/#example:example-match-subset-by-fragment
+
+### Overlay matching on a specific document by index
+
+https://carvel.dev/ytt/#example:example-match-by-index
+
+### Overlay matching on an array item by a specific field or key
+
+https://carvel.dev/ytt/#example:example-match-by-key
+
+### Overlay that inserts an array item at a specific spot
+
+https://carvel.dev/ytt/#example:example-insert-array-item
+
+### Overlay that replaces an array item
+
+https://carvel.dev/ytt/#example:example-replace-array-item
+
+### Overlay that removes or deletes an array item
+
+https://carvel.dev/ytt/#example:example-remove-array-item
+
+### Overlay that edits or modifies an array item in place
+
+https://carvel.dev/ytt/#example:example-edit-array-item
+
+### Overlay that appends an array item (inserts at the end) 
+
+https://carvel.dev/ytt/#example:example-append-array-item
+
+### Overlay that completely replaces the contents of an array
+
+https://carvel.dev/ytt/#example:example-replace-array
+
+### Overlay that adds a new map item or field
+
+https://carvel.dev/ytt/#example:example-add-map-item
+
+### Overlay that edits the value of a map item or field
+
+https://carvel.dev/ytt/#example:example-edit-map-value
+
+### Overlay that removes or deletes a map item or field
+
+https://carvel.dev/ytt/#example:example-remove-map-item
+
+### Overlay that renames the key or field of a map item
+
+https://carvel.dev/ytt/#example:example-rename-key-in-map
+
+### Overlay that add or appends a map into an array item
+
+https://carvel.dev/ytt/#example:example-append-map-to-array

--- a/site/content/ytt/docs/v0.42.0/index-playground-examples.md
+++ b/site/content/ytt/docs/v0.42.0/index-playground-examples.md
@@ -1,0 +1,160 @@
+---
+aliases: [/ytt/docs/latest/index-playground-examples]
+title: Playground Examples Index
+---
+
+## Basics
+
+### How Plain YAML is parsed
+
+https://carvel.dev/ytt/#example:example-plain-yaml
+
+### Datatypes in Starlark are encoded in YAML
+
+https://carvel.dev/ytt/#example:example-datatypes
+
+### Local variables within a template
+
+https://carvel.dev/ytt/#example:example-variable
+
+### Surrounding YAML with an if statement
+
+https://carvel.dev/ytt/#example:example-if
+
+### Looping or Generating YAML with a for loop
+
+https://carvel.dev/ytt/#example:example-for
+
+### Making a mini-template or extracting a chunk of YAML using a function
+
+https://carvel.dev/ytt/#example:example-function
+
+### Including helper functions from another file using load()
+
+https://carvel.dev/ytt/#example:example-load
+
+### Encoding or hashing a string
+
+https://carvel.dev/ytt/#example:example-load-ytt-library-module
+
+### Including a function from a library
+
+https://carvel.dev/ytt/#example:example-load-custom-library-module
+
+### Asserting on a particular value or condition
+
+https://carvel.dev/ytt/#example:example-assert
+
+### Declaring and using Data Values
+
+https://carvel.dev/ytt/#example:example-load-data-values
+
+### Loading and including data from a text or CSV file
+
+https://carvel.dev/ytt/#example:example-load-data-files
+
+### Templating strings and key names using text templating
+
+https://carvel.dev/ytt/#example:example-text-template
+
+### Inserting a YAML fragment or a value using template.replace()
+
+https://carvel.dev/ytt/#example:example-replace
+
+### Modifying or editing a YAML fragment with an overlay
+
+https://carvel.dev/ytt/#example:example-overlay
+
+### Writing an overlay that applies over all the other documents
+
+https://carvel.dev/ytt/#example:example-overlay-files
+
+### Splitting data values into multiple files
+
+https://carvel.dev/ytt/#example:example-multiple-data-values
+
+### Grouping and using multiple templates as a set using libraries
+
+https://carvel.dev/ytt/#example:example-ytt-library-module
+
+### Simple Kubernetes example with a Pod and a Service
+
+https://carvel.dev/ytt/#example:example-k8s-ingress-single
+
+### Kubernetes example producing multiple applications from data values
+
+https://carvel.dev/ytt/#example:example-k8s-ingress-multiple
+
+### Helm Chart like output from ytt
+
+https://carvel.dev/ytt/#example:example-k8s-helm-ish
+
+### A complete working example of many ytt features
+
+https://carvel.dev/ytt/#example:example-demo
+
+## Overlays
+
+### Overlay matching on all documents
+
+https://carvel.dev/ytt/#example:example-match-all-docs
+
+### Overlay matching on specific documents
+
+https://carvel.dev/ytt/#example:example-match-subset-docs
+
+### Overlay matching on specific documents using a YAML Fragment
+
+https://carvel.dev/ytt/#example:example-match-subset-by-fragment
+
+### Overlay matching on a specific document by index
+
+https://carvel.dev/ytt/#example:example-match-by-index
+
+### Overlay matching on an array item by a specific field or key
+
+https://carvel.dev/ytt/#example:example-match-by-key
+
+### Overlay that inserts an array item at a specific spot
+
+https://carvel.dev/ytt/#example:example-insert-array-item
+
+### Overlay that replaces an array item
+
+https://carvel.dev/ytt/#example:example-replace-array-item
+
+### Overlay that removes or deletes an array item
+
+https://carvel.dev/ytt/#example:example-remove-array-item
+
+### Overlay that edits or modifies an array item in place
+
+https://carvel.dev/ytt/#example:example-edit-array-item
+
+### Overlay that appends an array item (inserts at the end) 
+
+https://carvel.dev/ytt/#example:example-append-array-item
+
+### Overlay that completely replaces the contents of an array
+
+https://carvel.dev/ytt/#example:example-replace-array
+
+### Overlay that adds a new map item or field
+
+https://carvel.dev/ytt/#example:example-add-map-item
+
+### Overlay that edits the value of a map item or field
+
+https://carvel.dev/ytt/#example:example-edit-map-value
+
+### Overlay that removes or deletes a map item or field
+
+https://carvel.dev/ytt/#example:example-remove-map-item
+
+### Overlay that renames the key or field of a map item
+
+https://carvel.dev/ytt/#example:example-rename-key-in-map
+
+### Overlay that add or appends a map into an array item
+
+https://carvel.dev/ytt/#example:example-append-map-to-array

--- a/site/data/ytt/docs/ytt-develop-toc.yml
+++ b/site/data/ytt/docs/ytt-develop-toc.yml
@@ -105,3 +105,5 @@ toc:
         shared_url: /security-policy
       - page: Known Limitations
         url: /known-limitations
+      - page: Playground Examples
+        url: /index-playground-examples

--- a/site/data/ytt/docs/ytt-v0-42-0-toc.yml
+++ b/site/data/ytt/docs/ytt-v0-42-0-toc.yml
@@ -103,3 +103,5 @@ toc:
         shared_url: /security-policy
       - page: Known Limitations
         url: /known-limitations
+      - page: Playground Examples
+        url: /index-playground-examples


### PR DESCRIPTION
So that Algolia picks-up and indexes the examples, making them more discoverable.