### PR TITLE
[docs] Refer to the fork `k14s/semver` instead of `blang/semver`

### DIFF
--- a/site/content/kapp-controller/docs/develop/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/develop/package-consumer-concepts.md
@@ -83,7 +83,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.31.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.31.0/package-consumer-concepts.md
@@ -79,7 +79,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.32.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.32.0/package-consumer-concepts.md
@@ -79,7 +79,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.33.1/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.33.1/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.34.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.34.0/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.35.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.35.0/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.36.1/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.36.1/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.37.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.37.0/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.38.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.38.0/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.39.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.39.0/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.40.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.40.0/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/kapp-controller/docs/v0.41.0/package-consumer-concepts.md
+++ b/site/content/kapp-controller/docs/v0.41.0/package-consumer-concepts.md
@@ -84,7 +84,7 @@ PackageInstalls offer a property called `constraints` under
 used to select a specific version of a Package CR to install or include a set of
 conditions to pick a version. This `constraints` property is based on semver
 ranges and more details on conditions that can be included with `constraints`
-can be found [here](https://github.com/blang/semver#ranges).
+can be found [here](https://github.com/k14s/semver#ranges).
 
 To select a specific version of a Package CR to use with a PackageInstall, the
 full version (i.e. `.spec.version` from a Package CR) can be included in the

--- a/site/content/vendir/docs/develop/versions.md
+++ b/site/content/vendir/docs/develop/versions.md
@@ -31,11 +31,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 

--- a/site/content/vendir/docs/v0.24.0/versions.md
+++ b/site/content/vendir/docs/v0.24.0/versions.md
@@ -32,11 +32,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 

--- a/site/content/vendir/docs/v0.25.0/versions.md
+++ b/site/content/vendir/docs/v0.25.0/versions.md
@@ -32,11 +32,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 

--- a/site/content/vendir/docs/v0.26.0/versions.md
+++ b/site/content/vendir/docs/v0.26.0/versions.md
@@ -32,11 +32,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 

--- a/site/content/vendir/docs/v0.27.0/versions.md
+++ b/site/content/vendir/docs/v0.27.0/versions.md
@@ -32,11 +32,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 

--- a/site/content/vendir/docs/v0.29.0/versions.md
+++ b/site/content/vendir/docs/v0.29.0/versions.md
@@ -32,11 +32,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 

--- a/site/content/vendir/docs/v0.30.0/versions.md
+++ b/site/content/vendir/docs/v0.30.0/versions.md
@@ -32,11 +32,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 

--- a/site/content/vendir/docs/v0.31.0/versions.md
+++ b/site/content/vendir/docs/v0.31.0/versions.md
@@ -32,11 +32,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 

--- a/site/content/vendir/docs/v0.32.0/versions.md
+++ b/site/content/vendir/docs/v0.32.0/versions.md
@@ -32,11 +32,12 @@ semver:
 ---
 ## Semver
 
-[github.com/blang/semver/v4 package](https://github.com/blang/semver) is used for parsing "semver" versions.
+[github.com/k14s/semver/v4 package](https://github.com/k14s/semver) is used for parsing "semver" versions.
+It's a fork of [k14s/semver](https://github.com/k14s/semver).
 
 For valid semver syntax refer to <https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions>. (Commonly-used `v` prefix will be ignored during parsing)
 
-For constraints syntax refer to [blang/semver's Ranges section](https://github.com/blang/semver#ranges).
+For constraints syntax refer to [k14s/semver's Ranges section](https://github.com/k14s/semver#ranges).
 
 By default prerelease versions are not included in selection. See examples for details.
 


### PR DESCRIPTION
What remains is to update `k14s/semver`'s README to document its drift from `blang/semver`