### PR TITLE
updated banner for sandbox announcement

### DIFF
--- a/site/themes/carvel/layouts/partials/_banner.html
+++ b/site/themes/carvel/layouts/partials/_banner.html
@@ -1,5 +1,5 @@
 <div class="pageinfo pageinfo--red" style="text-align:center; margin:1px; display:flex; justify-content: center">
   <span style="margin: 0px; padding: 8px; background-color:#fff7b3; width: 100%;">
-    Carvel is heading to KubeCon + CloudNativeCon North America. Check out where to find us <a href="/blog/carvel-gitopscon-kubecon-na-2022/">here</a>!
+    Carvel is now a CNCF Sandbox project! Read about this exciting next step in our journey <a href="/blog/carvel-cncf-sandbox/">here</a>.
   </span>
 </div>


### PR DESCRIPTION
Removed the KubeCon announcement banner and replaced with pointing to CNCF Sandbox announcement.