### PR TITLE
Add missing "path:" fields from all fetch flavors

### DIFF
--- a/site/content/kapp-controller/docs/develop/app-spec.md
+++ b/site/content/kapp-controller/docs/develop/app-spec.md
@@ -87,6 +87,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -106,6 +108,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -119,6 +123,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -143,6 +149,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -158,6 +166,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.33.1/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.33.1/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.34.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.34.0/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.35.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.35.0/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.36.1/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.36.1/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.37.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.37.0/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.38.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.38.0/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.39.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.39.0/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.40.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.40.0/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.41.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.41.0/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:

--- a/site/content/kapp-controller/docs/v0.42.0/app-spec.md
+++ b/site/content/kapp-controller/docs/v0.42.0/app-spec.md
@@ -88,6 +88,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # pulls imgpkg bundle from Docker/OCI registry (v0.17.0+)
     - imgpkgBundle:
@@ -107,6 +109,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses http library to fetch file
     - http:
@@ -120,6 +124,8 @@ spec:
           name: secret-name
         # grab only portion of download (optional)
         subPath: inside-dir/dir2
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses git to clone repository
     - git:
@@ -144,6 +150,8 @@ spec:
             prereleases:
               # select prerelease versions that include given identifiers (optional; v0.24.0+)
               identifiers: [beta, rc]
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
     # uses helm fetch to fetch specified chart
     - helmChart:
@@ -159,6 +167,8 @@ spec:
           # (optional)
           secretRef:
             name: secret-name
+      # Relative path to place the fetched artifacts
+      path: dir (optional; v0.33.1+)
 
   # Template must have one or more directives
   template:


### PR DESCRIPTION
This is already implemented. It was documented only for the `inline:` flavor.

Supports cases like: https://kubernetes.slack.com/archives/CH8KCCKA5/p1667600088301069