### PR TITLE
replace confusing wording

### DIFF
--- a/site/content/kapp/docs/develop/apply.md
+++ b/site/content/kapp/docs/develop/apply.md
@@ -106,7 +106,7 @@ Available in v0.43.0+
 
 `kapp.k14s.io/exists` will ensure that resource exists in Kubernetes. It will not be considered to be part of the app (not labeled).
 
-If the resource is not present already, then kapp uses the `exists` operation and ensures that the resource exists in Kubernetes. 
+If the resource is not present already, then kapp uses the `exists` operation and assert that the resource exists in Kubernetes. 
 
 If the resource already exists, kapp does not perform any operation on it (the `noop` operation is used).
 


### PR DESCRIPTION
The word `ensure` in this sentence makes the expected behavior ambiguous:

```
If the resource is not present already, then kapp uses the `exists` operation and ensures that the resource exists in Kubernetes. 
```

Using `ensures` in this sentence gives the impression that it will make sure the resource will exist. The controller does not do this, it asserts if the resource exists, but does not create it if it does not.