### PR TITLE
Refine documentation for fetch.git.subpath

### DIFF
--- a/site/content/kapp-controller/docs/develop/app-spec.md
+++ b/site/content/kapp-controller/docs/develop/app-spec.md
@@ -136,7 +136,7 @@ spec:
         # (if ssh-knownhosts is not specified, git will not perform strict host checking)
         secretRef:
           name: secret-name
-        # grab only portion of repository (optional)
+        # grab only portion of repository. subpath becomes new root (optional)
         subPath: config-step-2-template
         # skip lfs download (optional)
         lfsSkipSmudge: true


### PR DESCRIPTION
To remove ambiguity that the root would remain the same but only the subpath is preserved (i.e users could incorrectly think absolute paths within the repo would be preserved)

See related code:
https://github.com/carvel-dev/kapp-controller/blob/ad24bdc3e41219b176f88280a469e9fd21979339/pkg/fetch/vendir.go#L157-L157

Related PR: https://github.com/carvel-dev/kapp-controller/pull/1061