### PR TITLE
more complete rewording of the section

### DIFF
--- a/site/content/kapp/docs/develop/apply.md
+++ b/site/content/kapp/docs/develop/apply.md
@@ -104,11 +104,11 @@ Possible values: "" (default), `containerName1`, `containerName1,containerName2`
 
 Available in v0.43.0+
 
-`kapp.k14s.io/exists` will ensure that resource exists in Kubernetes. It will not be considered to be part of the app (not labeled).
+`kapp.k14s.io/exists` verifies that the resource exists in Kubernetes. Kapp does not consider the resource a part of the app (not labeled).
 
-If the resource is not present already, then kapp uses the `exists` operation and assert that the resource exists in Kubernetes. 
+If the resource is not present, then kapp uses the `exists` operation and asserts that the resource exists in Kubernetes. 
 
-If the resource already exists, kapp does not perform any operation on it (the `noop` operation is used).
+If the resource already exists, kapp does not perform any operation on it (using the `noop` operation).
 
 Possible values: "".
 


### PR DESCRIPTION
I had trouble getting the rebase right for the signoff for [PR 620](https://github.com/carvel-dev/carvel/pull/620). So I re-created it.

This PR rewords the section related to the `kapp.k14.io/exists` annotation. It is intended to clarify that the Kapp Controller doesn't create the resource; it only verifies its existence.

I'll close the other PR.
