### PR TITLE
:pencil: update filename in rebaseRules docs

### DIFF
--- a/site/content/kapp/docs/develop/rebase-pvc.md
+++ b/site/content/kapp/docs/develop/rebase-pvc.md
@@ -86,7 +86,7 @@ rebaseRules:
 ```
 
 ```bash
-$ kapp deploy -a test -f config.yml -f rules.yml -c
+$ kapp deploy -a test -f config.yml -f kapp-config.yml -c
 
 Target cluster 'https://x.x.x.x' (nodes: gke-dk-jan-9-default-pool-a218b1c9-55sl, 3+)
 


### PR DESCRIPTION
TL;DR
=====
- Docs previously referred to `kapp-config.yml`, which doesn't appear in the example implementation; amended the example to include `kapp-config.yml` (intead of `rules.yml`)