### PR TITLE
Capitalized "H" in "GitHub"

### DIFF
--- a/site/content/community/_index.html
+++ b/site/content/community/_index.html
@@ -15,7 +15,7 @@ title: "Community"
                 <img src="/img/github-image.svg" />
             </div>
             <div class="content">
-                <h3><a href="{{% named_link_url "github_url" %}}" target="_blank">Check out Github</a></h3>
+                <h3><a href="{{% named_link_url "github_url" %}}" target="_blank">Check out GitHub</a></h3>
                 <p>You can follow the work we do, be part of on-going discussions, and examine our improvement ideas on each respective project's GitHub issues page.</p>
                 <p>If you're a newcomer, check out the <code>good first issue</code> label in each repository, take <a href="https://github.com/vmware-tanzu/carvel-kapp/labels/good%20first%20issue" target="_blank">kapp</a> for example.</p>
                 <p>If you are ready to jump in and add code, tests, or help with documentation, follow the guidelines in the <a href="/shared/docs/latest/contributing/">contributing documentation</a> in the respective repository.</p>


### PR DESCRIPTION
"H" in "GitHub" should be capitalized, based on both standard English capitalization rules and GitHub's own style guide.