### PR TITLE
Fix ytt examples links on `lang-ref-load` page

### DIFF
--- a/site/content/ytt/docs/develop/lang-ref-load.md
+++ b/site/content/ytt/docs/develop/lang-ref-load.md
@@ -110,5 +110,5 @@ sub-dir/_ytt_lib/weird-lib/funcs.lib.yml
 ## Examples
 
 - [Load](/ytt/#example:example-load)
-- [Load ytt library](/ytt/#example:example-load-ytt-library)
-- [Load custom library](/ytt/#example:example-load-custom-library)
+- [Load ytt library](/ytt/#example:example-load-ytt-library-module)
+- [Load custom library](/ytt/#example:example-load-custom-library-module)


### PR DESCRIPTION
Add `-module` to end of links.