### PR TITLE
add optional flag in git configuration to skip SSL/TLS verification

### DIFF
--- a/site/content/vendir/docs/develop/vendir-spec.md
+++ b/site/content/vendir/docs/develop/vendir-spec.md
@@ -43,8 +43,8 @@ directories:
             identifiers: [beta, rc]
       # skip downloading lfs files (optional)
       lfsSkipSmudge: false
-      # skip SSL verification (optional)
-      skipSslVerification: false
+      # skip SSL/TLS verification (optional)
+      dangerousSkipTLSVerify: false
       # skip initializing any git submodules (optional; v0.28.0+)
       skipInitSubmodules: false
       # verify gpg signatures on commits or tags (optional; v0.12.0+)

--- a/site/content/vendir/docs/develop/vendir-spec.md
+++ b/site/content/vendir/docs/develop/vendir-spec.md
@@ -43,6 +43,8 @@ directories:
             identifiers: [beta, rc]
       # skip downloading lfs files (optional)
       lfsSkipSmudge: false
+      # skip SSL verification (optional)
+      skipSslVerification: false
       # skip initializing any git submodules (optional; v0.28.0+)
       skipInitSubmodules: false
       # verify gpg signatures on commits or tags (optional; v0.12.0+)


### PR DESCRIPTION
Updating vendir docs with the new feature - add optional flag in git configuration to skip ssl verification