### PR TITLE
Add vanity URL support for carvel golang packages

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -215,3 +215,7 @@ markup:
     tabWidth: 4
 permalinks:
   tags: /blog/tags/:slug
+minify:
+  tdewolff:
+    html:
+      keepQuotes: true

--- a/site/content/imgpkg/_index.html
+++ b/site/content/imgpkg/_index.html
@@ -1,5 +1,7 @@
 ---
 title: "imgpkg"
+repo: "https://github.com/carvel-dev/imgpkg"
+packages: ["carvel.dev/imgpkg"]
 ---
 
 <div class="hero subpage imgpkg">

--- a/site/content/kapp-controller/_index.html
+++ b/site/content/kapp-controller/_index.html
@@ -1,5 +1,7 @@
 ---
 title: "kapp-controller"
+repo: "https://github.com/carvel-dev/kapp-controller"
+packages: ["carvel.dev/kapp-controller"]
 ---
 
 <div class="hero subpage kapp-controller">

--- a/site/content/kapp/_index.html
+++ b/site/content/kapp/_index.html
@@ -1,5 +1,7 @@
 ---
 title: "kapp"
+repo: "https://github.com/carvel-dev/kapp"
+packages: ["carvel.dev/kapp"]
 ---
 
 <div class="hero subpage kapp">

--- a/site/content/kbld/_index.html
+++ b/site/content/kbld/_index.html
@@ -1,5 +1,7 @@
 ---
 title: "kbld"
+repo: "https://github.com/carvel-dev/kbld"
+packages: ["carvel.dev/kbld"]
 ---
 
 <div class="hero subpage kbld">

--- a/site/content/vendir/_index.html
+++ b/site/content/vendir/_index.html
@@ -1,5 +1,7 @@
 ---
 title: "vendir"
+repo: "https://github.com/carvel-dev/vendir"
+packages: ["carvel.dev/vendir"]
 ---
 
 <div class="hero subpage vendir">

--- a/site/content/ytt/_index.html
+++ b/site/content/ytt/_index.html
@@ -1,5 +1,7 @@
 ---
 title: "Carvel - ytt"
+repo: "https://github.com/carvel-dev/ytt"
+packages: ["carvel.dev/ytt"]
 ---
 
 <script src="js/deps.js"></script>

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo --gc --minify"
 
 [context.production.environment]
-HUGO_VERSION = "0.78.0"
+HUGO_VERSION = "0.119.0"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,20 +11,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.78.0"
+HUGO_VERSION = "0.119.0"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.78.0"
+HUGO_VERSION = "0.119.0"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.78.0"
+HUGO_VERSION = "0.119.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"

--- a/site/themes/carvel/layouts/partials/meta.html
+++ b/site/themes/carvel/layouts/partials/meta.html
@@ -84,3 +84,9 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 <meta name="apple-touch-fullscreen" content="yes" />
+
+{{ if .Params.packages }}
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="go-import" content="{{ index .Params.packages 0 }} git {{ .Params.repo }}" />
+<meta name="go-source" content="{{ index .Params.packages 0 }} {{ .Params.repo }} {{ .Params.repo }}/tree/master{/dir} {{.Params.repo}}/blob/master{/dir}/{file}#L{line}" />
+{{ end }}


### PR DESCRIPTION
In this PR we prepare the website to serve the needed vanity URLs for the carvel golang packages.