### PR TITLE
Document `lazy` option in the vendir spec

### DIFF
--- a/site/content/vendir/docs/develop/vendir-spec.md
+++ b/site/content/vendir/docs/develop/vendir-spec.md
@@ -23,6 +23,11 @@ directories:
   - # path lives relative to directory path # (required)
     path: github.com/cloudfoundry/cf-k8s-networking
 
+    # skip fetching if the config for this path has not changed since the last sync
+    # optional, `false` by default, available since v0.36.0
+    # use `vendir sync --lazy=false` to forcefully sync when needed
+    lazy: true
+
     # uses git to clone Git repository (optional)
     git:
       # http or ssh urls are supported (required)


### PR DESCRIPTION
The option was proposed in [1] and implemented in [2].

[1]: https://github.com/carvel-dev/carvel/blob/develop/proposals/vendir/001-lazy-synching-on-stable-config/README.md
[2]: https://github.com/carvel-dev/vendir/pull/279