### PR TITLE
Update preflight option

### DIFF
--- a/site/content/kapp/docs/develop/preflight.md
+++ b/site/content/kapp/docs/develop/preflight.md
@@ -8,7 +8,7 @@ Once the change set is calculated (see [Diff](diff.md) section for details), kap
 
 If all enabled preflight checks are successful, kapp will continue to apply the changes in the change set (see [Apply](apply.md) section for further details).
 
-Preflight checks are enabled using the new `--preflight` flag when running `kapp deploy...` or `kapp app-group deploy...`. The `--preflight` flag follows the pattern `--preflight=CheckName=true,OtherCheck=false,...` to enable/disable preflight checks.
+Preflight checks are enabled using the new `--preflight` flag when running `kapp deploy...` or `kapp app-group deploy...`. The `--preflight` flag follows the pattern `--preflight=CheckName,OtherCheck,...` to enable the specified preflight checks. Preflight checks not specified are disabled.
 
 Currently available preflight checks are:
 - `PermissionValidation` - *disabled by default* - Validates that a user has the permissions necessary to apply the changes in the change set. If a user does not have the appropriate permissions the preflight check will fail and no changes will be applied to the cluster.
@@ -17,7 +17,7 @@ Currently available preflight checks are:
 
 The `PermissionValidation` preflight check validates that a user has the permissions necessary to apply the changes in the change set to the cluster. If a user does not have the appropriate permissions to apply *all* of the changes, this check will fail and result in no changes being applied to the cluster.
 
-This preflight check is disabled by default but can be enabled with `--preflight=PermissionValidation=true` when running `kapp deploy...` or `kapp app-group deploy...`.
+This preflight check is disabled by default but can be enabled with `--preflight=PermissionValidation` when running `kapp deploy...` or `kapp app-group deploy...`.
 
 The following permission checks are run when this check is enabled:
 - For all resources, verification that a user has the permissions to perform the change operation (`create`, `update`, `delete`).


### PR DESCRIPTION
Update the `--preflight` option to indicate that it only specifies the preflight checks to be enabled.