### PR TITLE
Use --app-namespace rather than -n for dedicated option in state-namespace docs

### DIFF
--- a/site/content/kapp/docs/develop/state-namespace.md
+++ b/site/content/kapp/docs/develop/state-namespace.md
@@ -6,7 +6,7 @@ title: Namespace for State Storage
 
 To show list of deployed applications (via `kapp ls`), kapp manages metadata `ConfigMap` for each saved application. Each metadata `ConfigMap` contains generated label used to label all application resources. Additionally kapp creates `ConfigMap` per each deploy to record deployment history (seen via `kapp app-change list -a app1`).
 
-`-n` (`--namespace`) flag allows to control which namespace is used for finding and storing metadata `ConfigMaps`. If namespace is not explicitly specified your current namespace is selected from kube config (typically `~/.kube/config`).
+`--app-namespace` flag allows to control which namespace is used for finding and storing metadata `ConfigMaps`. If namespace is not explicitly specified the app-wide namespace is used as specified by `-n` or `--namespace`); if `-n` is not specified your current namespace is selected from kube config (typically `~/.kube/config`).
 
 There are currently two approaches to deciding which namespace to use for storing metadata `ConfigMaps`:
 
@@ -22,8 +22,8 @@ There are currently two approaches to deciding which namespace to use for storin
 
    ```bash
     $ kubectl create ns apps
-    $ kapp deploy -n apps -f app1/config.yml
-    $ kapp deploy -n apps -f app2/config.yml
+    $ kapp deploy --app-namespace apps -f app1/config.yml
+    $ kapp deploy --app-namespace apps -f app2/config.yml
     $ kapp ls -n apps
     ```
 

--- a/site/content/kapp/docs/v0.59.x/state-namespace.md
+++ b/site/content/kapp/docs/v0.59.x/state-namespace.md
@@ -7,7 +7,7 @@ title: Namespace for State Storage
 
 To show list of deployed applications (via `kapp ls`), kapp manages metadata `ConfigMap` for each saved application. Each metadata `ConfigMap` contains generated label used to label all application resources. Additionally kapp creates `ConfigMap` per each deploy to record deployment history (seen via `kapp app-change list -a app1`).
 
-`-n` (`--namespace`) flag allows to control which namespace is used for finding and storing metadata `ConfigMaps`. If namespace is not explicitly specified your current namespace is selected from kube config (typically `~/.kube/config`).
+`--app-namespace` flag allows to control which namespace is used for finding and storing metadata `ConfigMaps`. If namespace is not explicitly specified the app-wide namespace is used as specified by `-n` or `--namespace`); if `-n` is not specified your current namespace is selected from kube config (typically `~/.kube/config`).
 
 There are currently two approaches to deciding which namespace to use for storing metadata `ConfigMaps`:
 
@@ -23,8 +23,8 @@ There are currently two approaches to deciding which namespace to use for storin
 
    ```bash
     $ kubectl create ns apps
-    $ kapp deploy -n apps -f app1/config.yml
-    $ kapp deploy -n apps -f app2/config.yml
+    $ kapp deploy --app-namespace apps -f app1/config.yml
+    $ kapp deploy --app-namespace apps -f app2/config.yml
     $ kapp ls -n apps
     ```
 

--- a/site/content/kapp/docs/v0.60.x/state-namespace.md
+++ b/site/content/kapp/docs/v0.60.x/state-namespace.md
@@ -7,7 +7,7 @@ title: Namespace for State Storage
 
 To show list of deployed applications (via `kapp ls`), kapp manages metadata `ConfigMap` for each saved application. Each metadata `ConfigMap` contains generated label used to label all application resources. Additionally kapp creates `ConfigMap` per each deploy to record deployment history (seen via `kapp app-change list -a app1`).
 
-`-n` (`--namespace`) flag allows to control which namespace is used for finding and storing metadata `ConfigMaps`. If namespace is not explicitly specified your current namespace is selected from kube config (typically `~/.kube/config`).
+`--app-namespace` flag allows to control which namespace is used for finding and storing metadata `ConfigMaps`. If namespace is not explicitly specified the app-wide namespace is used as specified by `-n` or `--namespace`); if `-n` is not specified your current namespace is selected from kube config (typically `~/.kube/config`).
 
 There are currently two approaches to deciding which namespace to use for storing metadata `ConfigMaps`:
 
@@ -23,8 +23,8 @@ There are currently two approaches to deciding which namespace to use for storin
 
    ```bash
     $ kubectl create ns apps
-    $ kapp deploy -n apps -f app1/config.yml
-    $ kapp deploy -n apps -f app2/config.yml
+    $ kapp deploy --app-namespace apps -f app1/config.yml
+    $ kapp deploy --app-namespace apps -f app2/config.yml
     $ kapp ls -n apps
     ```
 


### PR DESCRIPTION
When using a dedicated namespace for state storage, the docs currently suggest specifying this namespace via the `-n` flag. However this can lead to undesirable behaviors, since the app is typically being deployed to a different namespace. In my case, I had a resource where I had neglected to specify the namespace, and it would have ended up getting deployed to the state-storage namespace rather than the same namespace as the rest of the app.

This was discussed in https://github.com/carvel-dev/kapp/issues/815 and fixed in https://github.com/carvel-dev/kapp/pull/814 with the introduction of the `--app-namespace` flag, which controls which is used for state storage independently of the app namespace. However the docs did not reflect this change.

This commit adjusts the documentation to recommend using `--app-namespace` when storing configs in a separate namespace.