### PR TITLE
ytt: document schema/desc and schema/title

### DIFF
--- a/site/content/ytt/docs/develop/how-to-write-schema.md
+++ b/site/content/ytt/docs/develop/how-to-write-schema.md
@@ -44,6 +44,17 @@ system_domain: ""
 
 declares the Data Value, with the name `system_domain` to be of type **string** with the default value of an **empty string** (i.e. `""`).
 
+Additionally, a Data Value can also have a **title** and a **description** to make the schema easier to understand.
+
+For example,
+```yaml
+#@data/values-schema
+---
+#@schema/title "The system domain name"
+#@schema/desc "The domain this system will be available at"
+system_domain: ""
+```
+
 ---
 ## Implying Types
 


### PR DESCRIPTION
YTT supports declaring a `title` as well as a `description` for each data value.

Currently this isn't clearly documented on the "how to write schema" page, but rather just mentioned on the "export to openapi" page.

To make this feature more visible it would make sense to document it with the other schema options.