### PR TITLE
Add vanity URL for SGC

### DIFF
--- a/site/content/secretgen-controller/_index.html
+++ b/site/content/secretgen-controller/_index.html
@@ -1,0 +1,5 @@
+---
+title: "secretgen-controller"
+repo: "https://github.com/carvel-dev/secretgen-controller"
+packages: ["carvel.dev/secretgen-controller"]
+---


### PR DESCRIPTION
This is needed so that the SGC go mod is accessible

If a user tries to navigate to SGC from the Navbar or the tiles in the homepage it still redirects to the GitHub.
If someone explicitly specifies `/secretgen-controller` in the URL, it leads to an empty page with a link to the GitHub. This however has the required meta that will let users use the renamed go module.

(This can be verified in the deploy preview ^)