### PR TITLE
Mention kapp default update strategy flag in faq

### DIFF
--- a/site/content/kapp/docs/develop/apply.md
+++ b/site/content/kapp/docs/develop/apply.md
@@ -43,6 +43,8 @@ In some cases entire resources or subset resource fields are immutable which for
 - `always-replace` causes kapp to always delete and then create resource (See note above as well.)
 - `skip` causes kapp to not apply update (it will show up in a diff next time). Available in v0.33.0+.
 
+There is also a CLI-wide flag `--apply-default-update-strategy`. If set, it will be used as a default value for all resources that do not have `kapp.k14s.io/update-strategy` annotation set. If used, consider explicitly annotating individual resources that should not be replaced with `""` or `"skip"`.
+
 ### kapp.k14s.io/delete-strategy
 
 `kapp.k14s.io/delete-strategy` annotation controls deletion behaviour

--- a/site/content/kapp/docs/develop/faq.md
+++ b/site/content/kapp/docs/develop/faq.md
@@ -29,6 +29,8 @@ See [state namespace](state-namespace.md) doc page.
 
 Some fields on a resource are immutable. kapp provides a `kapp.k14s.io/update-strategy` annotation that controls how kapp will update resource. One of the strategies is `fallback-on-replace` which will have kapp recreate an object (delete, wait, then create) if initial update results in `Invalid` error. See [Controlling apply via resource annotations](apply.md#controlling-apply-via-resource-annotations) for details.
 
+The CLI flag `--apply-default-update-strategy=fallback-on-replace` can be used to instruct `kapp` to default to this behavior for all resources. Consider specifically annotating specific resources you wish to protect from deletion if you use this.
+
 ---
 ## `Job.batch is invalid: ... spec.selector: Required value` error
 

--- a/site/content/kapp/docs/v0.63.x/apply.md
+++ b/site/content/kapp/docs/v0.63.x/apply.md
@@ -44,6 +44,8 @@ In some cases entire resources or subset resource fields are immutable which for
 - `always-replace` causes kapp to always delete and then create resource (See note above as well.)
 - `skip` causes kapp to not apply update (it will show up in a diff next time). Available in v0.33.0+.
 
+There is also a CLI-wide flag `--apply-default-update-strategy`. If set, it will be used as a default value for all resources that do not have `kapp.k14s.io/update-strategy` annotation set. If used, consider explicitly annotating individual resources that should not be replaced with `""` or `"skip"`.
+
 ### kapp.k14s.io/delete-strategy
 
 `kapp.k14s.io/delete-strategy` annotation controls deletion behaviour

--- a/site/content/kapp/docs/v0.63.x/faq.md
+++ b/site/content/kapp/docs/v0.63.x/faq.md
@@ -30,6 +30,8 @@ See [state namespace](state-namespace.md) doc page.
 
 Some fields on a resource are immutable. kapp provides a `kapp.k14s.io/update-strategy` annotation that controls how kapp will update resource. One of the strategies is `fallback-on-replace` which will have kapp recreate an object (delete, wait, then create) if initial update results in `Invalid` error. See [Controlling apply via resource annotations](apply.md#controlling-apply-via-resource-annotations) for details.
 
+The CLI flag `--apply-default-update-strategy=fallback-on-replace` can be used to instruct `kapp` to default to this behavior for all resources. Consider specifically annotating specific resources you wish to protect from deletion if you use this.
+
 ---
 ## `Job.batch is invalid: ... spec.selector: Required value` error
 


### PR DESCRIPTION
Add mention of the kapp `--apply-default-update-strategy` flag to the FAQ and the annotation docs.

This would've been helpful to me as it was not immediately obvious how to force kapp to replace resources in case of label conflicts or other issues that prevent patching.