### PR TITLE
docs: add vendir ignorePaths documentation

### DIFF
--- a/site/content/vendir/docs/develop/vendir-spec.md
+++ b/site/content/vendir/docs/develop/vendir-spec.md
@@ -264,6 +264,10 @@ directories:
     # LICENSE, NOTICE and COPYRIGHT variations (optional)
     legalPaths: []
 
+    # ignore paths from being overwritten or deleted by sync, preserving 
+    # the local file (optional)
+    ignorePaths: []
+
     # make subdirectory to be new root path within this asset (optional; v0.11.0+)
     newRootPath: cfroutesync
 


### PR DESCRIPTION
Adds `ignorePaths` documentation to the spec that appears on the web page https://carvel.dev/vendir/docs/v0.43.x/vendir-spec/
