### PR TITLE
chore: fix go-import meta tags

### DIFF
--- a/site/content/kapp-controller/_index.html
+++ b/site/content/kapp-controller/_index.html
@@ -1,7 +1,7 @@
 ---
 title: "kapp-controller"
 repo: "https://github.com/carvel-dev/kapp-controller"
-packages: ["carvel.dev/kapp-controller", "carvel.dev/kapp-controller/cli"]
+packages: ["carvel.dev/kapp-controller"]
 ---
 
 <div class="hero subpage kapp-controller">

--- a/site/content/kapp-controller/cli/_index.html
+++ b/site/content/kapp-controller/cli/_index.html
@@ -1,0 +1,29 @@
+---
+title: "kctrl"
+repo: "https://github.com/carvel-dev/kapp-controller"
+packages: ["carvel.dev/kapp-controller/cli"]
+---
+
+<head>
+  <!-- Meta tag for go-import -->
+  <meta name="go-import" content="carvel.dev/kapp-controller/cli git https://github.com/carvel-dev/kapp-controller">
+  <!-- Meta tag for go-source -->
+  <meta name="go-source" content="carvel.dev/kapp-controller/cli https://github.com/carvel-dev/kapp-controller/cli https://github.com/carvel-dev/kapp-controller/tree/develop/cli{/dir} https://github.com/carvel-dev/kapp-controller/blob/develop/cli{/dir}/{file}#L{line}">
+</head>
+
+<div class="hero subpage kapp-controller">
+  <div class="wrapper clearfix">
+    <div class="text-block">
+      <h1>kctrl cli</h1>
+      <p>
+        kctrl, aka kubectl on steroids, is a command line tool that provides a
+        declarative way to install, manage, and upgrade applications on a Kubernetes cluster.
+      </p>
+      <div class="buttons">
+        <a class="button tertiary" href="/kapp-controller/docs/latest/kctrl-package-authoring">More</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+

--- a/site/content/kapp-controller/cli/_index.html
+++ b/site/content/kapp-controller/cli/_index.html
@@ -4,13 +4,6 @@ repo: "https://github.com/carvel-dev/kapp-controller"
 packages: ["carvel.dev/kapp-controller/cli"]
 ---
 
-<head>
-  <!-- Meta tag for go-import -->
-  <meta name="go-import" content="carvel.dev/kapp-controller/cli git https://github.com/carvel-dev/kapp-controller">
-  <!-- Meta tag for go-source -->
-  <meta name="go-source" content="carvel.dev/kapp-controller/cli https://github.com/carvel-dev/kapp-controller/cli https://github.com/carvel-dev/kapp-controller/tree/develop/cli{/dir} https://github.com/carvel-dev/kapp-controller/blob/develop/cli{/dir}/{file}#L{line}">
-</head>
-
 <div class="hero subpage kapp-controller">
   <div class="wrapper clearfix">
     <div class="text-block">

--- a/site/themes/carvel/layouts/partials/_header.html
+++ b/site/themes/carvel/layouts/partials/_header.html
@@ -51,8 +51,8 @@
 {{ $info := (index .Site.Params .Section) }}
 <header class="subproject-specific">
 	<div class="wrapper">
-		<a href="{{ $info.root_link }}" class="text-logo">
-			<span class="long">{{ $info.name }}</span>
+		<a href="{{ .RelPermalink }}" class="text-logo">
+			<span class="long">{{trim .RelPermalink "/"}}</span>
 			<span class="short">{{ $info.short_name }}</span>
 		</a>
 		<ul class="desktop-links">

--- a/site/themes/carvel/layouts/partials/meta.html
+++ b/site/themes/carvel/layouts/partials/meta.html
@@ -89,8 +89,4 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="go-import" content="{{ index .Params.packages 0 }} git {{ .Params.repo }}" />
 <meta name="go-source" content="{{ index .Params.packages 0 }} {{ .Params.repo }} {{ .Params.repo }}/tree/develop{/dir} {{.Params.repo}}/blob/develop{/dir}/{file}#L{line}" />
-  {{ if eq .Params.title "kapp-controller"}}
-  <meta name="go-import" content="{{ index .Params.packages 1 }} git {{ .Params.repo }}" />
-  <meta name="go-source" content="{{ index .Params.packages 1 }} {{ .Params.repo }}/cli {{ .Params.repo }}/tree/develop/cli{/dir} {{.Params.repo}}/blob/develop/cli{/dir}/{file}#L{line}" />
-  {{ end }}
-{{ end }}
+{{end}}

--- a/site/themes/carvel/layouts/partials/meta.html
+++ b/site/themes/carvel/layouts/partials/meta.html
@@ -90,7 +90,7 @@
 <meta name="go-import" content="{{ index .Params.packages 0 }} git {{ .Params.repo }}" />
 <meta name="go-source" content="{{ index .Params.packages 0 }} {{ .Params.repo }} {{ .Params.repo }}/tree/develop{/dir} {{.Params.repo}}/blob/develop{/dir}/{file}#L{line}" />
   {{ if eq .Params.title "kapp-controller"}}
-  <meta name="go-import" content="{{ index .Params.packages 1 }} git {{ .Params.repo }}/cli" />
+  <meta name="go-import" content="{{ index .Params.packages 1 }} git {{ .Params.repo }}" />
   <meta name="go-source" content="{{ index .Params.packages 1 }} {{ .Params.repo }}/cli {{ .Params.repo }}/tree/develop/cli{/dir} {{.Params.repo}}/blob/develop/cli{/dir}/{file}#L{line}" />
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Fix the go-import meta tags so that kctrl can be imported via carvel.dev/kapp-controller/cli URL