### PR TITLE
Add notice for keyMatcher in kbld

### DIFF
--- a/site/content/kbld/docs/develop/config.md
+++ b/site/content/kbld/docs/develop/config.md
@@ -86,6 +86,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.32.0/config.md
+++ b/site/content/kbld/docs/v0.32.0/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.33.0/config.md
+++ b/site/content/kbld/docs/v0.33.0/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.34.0/config.md
+++ b/site/content/kbld/docs/v0.34.0/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.35.0/config.md
+++ b/site/content/kbld/docs/v0.35.0/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.36.0/config.md
+++ b/site/content/kbld/docs/v0.36.0/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.37.x/config.md
+++ b/site/content/kbld/docs/v0.37.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.38.x/config.md
+++ b/site/content/kbld/docs/v0.38.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.39.x/config.md
+++ b/site/content/kbld/docs/v0.39.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.40.x/config.md
+++ b/site/content/kbld/docs/v0.40.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.41.x/config.md
+++ b/site/content/kbld/docs/v0.41.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.42.x/config.md
+++ b/site/content/kbld/docs/v0.42.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.43.x/config.md
+++ b/site/content/kbld/docs/v0.43.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.44.x/config.md
+++ b/site/content/kbld/docs/v0.44.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\

--- a/site/content/kbld/docs/v0.45.x/config.md
+++ b/site/content/kbld/docs/v0.45.x/config.md
@@ -87,6 +87,8 @@ searchRules:
     path:
 ```
 
+**NOTICE:** `name` and `path` are mutually exclusive and `name` as precedence.
+
 where:
 - `name` (string) specifies the key name (e.g. `sidecarImage`)
 - `path` (array) specifies key path from the root of the YAML document.\


### PR DESCRIPTION
Clarify that the keyMatcher from kbld only support `name` or `path` and not both.