### PR TITLE
 Add Prerequisites Section to README for Better User Onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,22 @@ This is a list of repos associated with the [Carvel](https://carvel.dev) project
 * [kapp](https://github.com/carvel-dev/kapp) - Install, upgrade, and delete multiple Kubernetes resources as one "application"
 * [kbld](https://github.com/carvel-dev/kbld) - Build or reference container images in Kubernetes configuration in an immutable way
 * [imgpkg](https://github.com/carvel-dev/imgpkg) - Bundle and relocate application configuration (with images) via Docker registries
-* [kapp-controller](https://github.com/carvel-dev/kapp-controller) - Capture application deployment workflow in App CRD. Reliable GitOps experience powered by kapp.
-* [vendir](https://github.com/carvel-dev/vendir) - Declaratively state what files should be in a directory.
+* [kapp-controller](https://github.com/carvel-dev/kapp-controller) - Capture application deployment workflow in App CRD. Reliable GitOps experience powered by kapp.* [vendir](https://github.com/carvel-dev/vendir) - Declaratively state what files should be in a directory.
 * [secretgen-controller](https://github.com/carvel-dev/secretgen-controller) - Provides CRDs to specify what secrets need to be on a cluster (generated or not).
 ## Tool Overview Table
 
-The Carvel project includes multiple focused tools.  
-The following table gives a quick overview of each tool, its purpose, and links to documentation and source code.
+The Carvel project includes multiple focused tools.
 
 | Tool | Purpose | Documentation | Repository |
 |------|---------|---------------|------------|
 | **ytt** | YAML templating and overlays | https://carvel.dev/ytt/ | https://github.com/carvel-dev/ytt |
-| **kapp** | Kubernetes application deployment and lifecycle mgmt | https://carvel.dev/kapp/ | https://github.com/carvel-dev/kapp |
+| **kapp** | Kubernetes application deployment and lifecycle management | https://carvel.dev/kapp/ | https://github.com/carvel-dev/kapp |
 | **kbld** | Image building and immutable references | https://carvel.dev/kbld/ | https://github.com/carvel-dev/kbld |
 | **imgpkg** | Distribute config + images as OCI bundles | https://carvel.dev/imgpkg/ | https://github.com/carvel-dev/imgpkg |
 | **kapp-controller** | GitOps-style application controller | https://carvel.dev/kapp-controller/ | https://github.com/carvel-dev/kapp-controller |
 | **vendir** | Declarative file/directory vendoring | https://carvel.dev/vendir/ | https://github.com/carvel-dev/vendir |
 | **secretgen-controller** | CRDs for secret generation | https://carvel.dev/secretgen-controller/ | https://github.com/carvel-dev/secretgen-controller |
+
 
 Experimental:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ This is a list of repos associated with the [Carvel](https://carvel.dev) project
 * [kapp-controller](https://github.com/carvel-dev/kapp-controller) - Capture application deployment workflow in App CRD. Reliable GitOps experience powered by kapp.
 * [vendir](https://github.com/carvel-dev/vendir) - Declaratively state what files should be in a directory.
 * [secretgen-controller](https://github.com/carvel-dev/secretgen-controller) - Provides CRDs to specify what secrets need to be on a cluster (generated or not).
+## Tool Overview Table
+
+The Carvel project includes multiple focused tools.  
+The following table gives a quick overview of each tool, its purpose, and links to documentation and source code.
+
+| Tool | Purpose | Documentation | Repository |
+|------|---------|---------------|------------|
+| **ytt** | YAML templating and overlays | https://carvel.dev/ytt/ | https://github.com/carvel-dev/ytt |
+| **kapp** | Kubernetes application deployment and lifecycle mgmt | https://carvel.dev/kapp/ | https://github.com/carvel-dev/kapp |
+| **kbld** | Image building and immutable references | https://carvel.dev/kbld/ | https://github.com/carvel-dev/kbld |
+| **imgpkg** | Distribute config + images as OCI bundles | https://carvel.dev/imgpkg/ | https://github.com/carvel-dev/imgpkg |
+| **kapp-controller** | GitOps-style application controller | https://carvel.dev/kapp-controller/ | https://github.com/carvel-dev/kapp-controller |
+| **vendir** | Declarative file/directory vendoring | https://carvel.dev/vendir/ | https://github.com/carvel-dev/vendir |
+| **secretgen-controller** | CRDs for secret generation | https://carvel.dev/secretgen-controller/ | https://github.com/carvel-dev/secretgen-controller |
 
 Experimental:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ Experimental:
 
 * [kwt](https://github.com/carvel-dev/kwt)
 * [terraform-provider-carvel](https://github.com/carvel-dev/terraform-provider-carvel)
+## Prerequisites
+
+Before installing or using Carvel tools, ensure the following requirements are met:
+
+- **Kubernetes cluster** (local or remote)  
+  - You can use Minikube, Kind, k3d, or a managed Kubernetes service.
+- **kubectl installed and configured**  
+  - Verify using:  
+    ```bash
+    kubectl version --client
+    ```
+- **A container registry account** (optional but recommended)  
+  - Needed for tools like `kbld` and `imgpkg` when pushing or relocating images.
+- **macOS, Linux, or WSL2**  
+  - Carvel tools support modern Unix-like environments.
+
+These prerequisites help ensure that Carvel tools work consistently across different development setups.
 
 Installation:
 


### PR DESCRIPTION
This pull request (ID: sai-30624) adds a new **Prerequisites** section to the Carvel README to improve onboarding for new users.

### What This PR Adds
- A clear list of requirements needed before installing or using Carvel tools
- Kubernetes cluster requirement explanation
- kubectl installation check and command
- Optional container registry requirement
- Supported operating systems
- Logical placement before the Installation section

### Why This Change Is Important
The current README does not specify what users need prior to installation, which can lead to confusion or setup failures — especially for first-time Carvel users.  
This new Prerequisites section improves documentation clarity, user experience, and setup consistency.

**Author:** sai-30624  
**Email:** 2400030624@kluniversity.in
